### PR TITLE
Handle dates stored as strings, not objects.

### DIFF
--- a/features/step_definitions/eventbrite_steps.rb
+++ b/features/step_definitions/eventbrite_steps.rb
@@ -18,7 +18,7 @@ Given /^another event in Eventbrite called "(.*?)" with id (#{INTEGER})$/ do |ti
 end
 
 Given /^the event is happening on (#{DATE})$/ do |date|
-  @events.last['date'] = date
+  @events.last['starts_at'] = date.to_s
 end
 
 Given /^the event is happening in the past$/ do
@@ -44,11 +44,11 @@ Given /^that event has a url '(.*?)'$/ do |url|
 end
 
 Given /^that event starts at (#{DATETIME})$/ do |datetime|
-  @events.last['starts_at'] = datetime
+  @events.last['starts_at'] = datetime.to_s
 end
 
 Given /^that event ends at (#{DATETIME})$/ do |datetime|
-  @events.last['ends_at'] = datetime
+  @events.last['ends_at'] = datetime.to_s
 end
 
 Given /^that event is being held at '(.*?)'$/ do |location|
@@ -66,11 +66,11 @@ Given /^that event has (#{INTEGER}) tickets called "(.*?)" which cost ([A-Z]{3})
 end
 
 Given /^that ticket type is on sale from (#{DATETIME})$/ do |datetime|
-  @events.last['ticket_types'].last['starts_at'] = datetime
+  @events.last['ticket_types'].last['starts_at'] = datetime.to_s
 end
 
 Given /^that ticket type is on sale until (#{DATETIME})$/ do |datetime|
-  @events.last['ticket_types'].last['ends_at'] = datetime
+  @events.last['ticket_types'].last['ends_at'] = datetime.to_s
 end
 
 Then /^the net price of the event is (#{FLOAT})$/ do |price|

--- a/lib/eventbrite/attendee_invoicer.rb
+++ b/lib/eventbrite/attendee_invoicer.rb
@@ -90,7 +90,7 @@ class AttendeeInvoicer
       end
     end
     unless existing
-      date = event_details['starts_at'].to_date rescue nil
+      date = Date.parse(event_details['starts_at']) rescue nil
       # Build description
       description = "Registration for '#{event_details['title']} (#{date})' for #{user_details['first_name']} #{user_details['last_name']} <#{user_details['email']}> ("
       description += "Order number: #{payment_details['order_number']}" if payment_details['order_number']

--- a/lib/eventbrite/event_lister.rb
+++ b/lib/eventbrite/event_lister.rb
@@ -25,9 +25,9 @@ class EventLister
               'remaining' => t['quantity_available'],
               'price'     => t['price'].to_f,
               'currency'  => t['currency'],
-              'ends_at'   => DateTime.parse(t['end_date'])
+              'ends_at'   => DateTime.parse(t['end_date']).to_s
             }
-            tickets.last['starts_at'] = DateTime.parse(t['start_date']) if t['start_date']
+            tickets.last['starts_at'] = DateTime.parse(t['start_date']).to_s if t['start_date']
           end
           # Everything else
           events << {
@@ -35,8 +35,8 @@ class EventLister
             'live'         => true,
             'title'        => e['title'],
             'url'          => e['url'],
-            'starts_at'    => DateTime.parse(e['start_date']),
-            'ends_at'      => DateTime.parse(e['end_date']),
+            'starts_at'    => DateTime.parse(e['start_date']).to_s,
+            'ends_at'      => DateTime.parse(e['end_date']).to_s,
             'ticket_types' => tickets,
           }
           events.last['location'] = e['venue']['name'] if e['venue']


### PR DESCRIPTION
This is because everything is serialised through Redis as strings, so we need to:
- assume that everything in the incoming hashes is a string
- Update tests to store dates as strings, not date objects.

Fixes #102. 0:20
