### PR TITLE
Ignore BuildStatusMonitor errors

### DIFF
--- a/lib/jenkins/build_status_monitor.rb
+++ b/lib/jenkins/build_status_monitor.rb
@@ -22,6 +22,9 @@ class BuildStatusMonitor
       </div>
     EOF
     Resque.enqueue LeftronicPublisher, :html, ENV['LEFTRONIC_JENKINS_HTML'], html
+  rescue RuntimeError
+    # Sometimes the Jenkins CI gem will complain if there's any projects with a 'notbuilt' status. Just rescue from these an move on for now 
+    nil
   end
   
 end


### PR DESCRIPTION
The Services Manager logs are getting clogged up with errors from the BuildStatusMonitor, making it difficult to diagnose actual problems. Let's just ignore these for now and move on.
