### PR TITLE
Make sure invoices without a UID are always raised

### DIFF
--- a/lib/xero/invoicer.rb
+++ b/lib/xero/invoicer.rb
@@ -132,7 +132,7 @@ class Invoicer
   end
   
   def self.remember_invoice(key)
-    Resque.redis.set(key, true)
+    Resque.redis.set(key, true) unless key.nil?
   end
   
   def self.invoice_sent?(key)


### PR DESCRIPTION
The fix in #281 introduced a UID for Eventbrite issues, which is working well. However, other invoices (such as ones coming from the member directory) have a uid of `nil`, which gets cast as `"nil"` when accessing Redis, so no invoices with a uid of `nil` ever get raised (with the exception of the first one). This fixes that.
