### PR TITLE
Squeeze spaces in contact names

### DIFF
--- a/features/invoice_space_stripping.feature
+++ b/features/invoice_space_stripping.feature
@@ -5,7 +5,7 @@ Feature: Invoicing existing contacts with removal of extraneous spaces
   As a prospective delegate
   I want to be sent an invoice when I sign up to attend an event
 
-  Background:
+  Scenario: invoices are created despite extra spaces
     Given the invoice is due on 2013-03-10
     And the invoice amount is 1.00
     And the invoice description is "my fantastic invoice description"
@@ -15,9 +15,14 @@ Feature: Invoicing existing contacts with removal of extraneous spaces
     And I work for " Existing Company Inc. "
     And there is a contact in Xero for "Existing Company Inc."
     And I have not already been invoiced
-
-  Scenario: invoices are created despite extra spaces
-    Given I have registered for a ticket
+    And I have registered for a ticket
     And I paid with Paypal
     When the attendee invoicer runs
     Then an invoice should be raised in Xero against "Existing Company Inc."
+    
+  Scenario: invoice names with two spaces should be squeezed
+    Given my first name is "Bob "
+    And my last name is "Fish"
+    And I have an invoice contact email of "bob.fish@example.com"
+    When my contact name is generated
+    Then the generated name should be "Bob Fish (bob.fish@example.com)"

--- a/features/step_definitions/invoice_steps.rb
+++ b/features/step_definitions/invoice_steps.rb
@@ -48,3 +48,13 @@ end
 Then /^the invoice should be due on (#{DATE})$/ do |date|
   @invoice_due_date = date
 end
+
+# Spaces
+
+When(/^my contact name is generated$/) do
+  @contact_name = Invoicer.contact_name(create_invoice_to_hash)
+end
+
+Then(/^the generated name should be "(.*?)"$/) do |arg1|
+  @contact_name.should == arg1
+end

--- a/lib/xero/invoicer.rb
+++ b/lib/xero/invoicer.rb
@@ -116,7 +116,7 @@ class Invoicer
   def self.contact_name(invoice_to)
     name = invoice_to['name']
     if name.nil? || name.blank?
-      name = [invoice_to['contact_point']['name'], "(#{invoice_to['contact_point']['email']})"].join(' ')
+      name = [invoice_to['contact_point']['name'], "(#{invoice_to['contact_point']['email']})"].join(' ').squeeze(' ')
     end
     name.strip
   end


### PR DESCRIPTION
Make sure we don't get double spaces in contact names, because Xero complains.
