### PR TITLE
Individual member duration

### DIFF
--- a/lib/capsulecrm/capsule_helper.rb
+++ b/lib/capsulecrm/capsule_helper.rb
@@ -11,6 +11,16 @@ module CapsuleHelper
     CapsuleCRM::Person.find_all(:email => query).first
   end
 
+  def find_org_by_membership_id(membership_id)
+    parties = CapsuleCRM::Organisation.find_all(:q => membership_id)
+    parties.find{|x| field(x, "Membership", "ID").try(:text) == membership_id}
+  end
+
+  def find_person_by_membership_id(membership_id)
+    parties = CapsuleCRM::Person.find_all(:q => membership_id)
+    parties.find{|x| field(x, "Membership", "ID").try(:text) == membership_id}
+  end
+
   def set_membership_tag(party, fields)
     types = {
       "Level"           => :text,

--- a/lib/capsulecrm/save_membership_details_to_capsule.rb
+++ b/lib/capsulecrm/save_membership_details_to_capsule.rb
@@ -16,12 +16,12 @@ class SaveMembershipDetailsToCapsule
   # Returns nil.
 
   def self.perform(membership_id, membership)
-    org = find_organization(membership_id)
-    if org.nil?
+    party = find_org_by_membership_id(membership_id) || find_person_by_membership_id(membership_id)
+    if party.nil?
       requeue(membership_id, membership)
     else
       success = set_membership_tag(
-        org,
+        party,
         'Email'      => membership['email'],
         'Newsletter' => membership['newsletter'],
         'Size'       => membership['size'],

--- a/lib/signup/product_helper.rb
+++ b/lib/signup/product_helper.rb
@@ -27,7 +27,9 @@ module ProductHelper
 
   def product_duration(product)
     case product.to_sym
-    when :supporter, :individual
+    when :individual
+      1
+    when :supporter
       12
     when :sponsor, :partner
       3


### PR DESCRIPTION
and membership detail update matching for people. Because PRs are rationed.