### PR TITLE
Add contacts directly to Capsule

### DIFF
--- a/features/adding_people_to_capsule.feature
+++ b/features/adding_people_to_capsule.feature
@@ -32,3 +32,17 @@ Feature: Add person details to Capsule CRM
     And that data tag should have the membership number "HG5646HD"
     And that data tag should have the sector "Healthcare"
     And that data tag should have the email "rimmer@jmc.com"
+
+  Scenario: attach membership tag to new person
+    Given I requested 1 membership at the level called "individual"
+    And there is no person in CapsuleCRM called "Arnold Rimmer"
+    And that it's 2013-01-01 14:35
+    When I sign up via the website
+    Then there should still be just one person in CapsuleCRM called "Arnold Rimmer" with email "rimmer@jmc.com"
+    And that person should have a data tag
+    And that data tag should have the type "Membership"
+    And that data tag should have the level "individual"
+    And that data tag should have the join date 2013-01-01
+    And that data tag should have the membership number "HG5646HD"
+    And that data tag should have the sector "Healthcare"
+    And that data tag should have the email "rimmer@jmc.com"

--- a/features/member_signup_processing.feature
+++ b/features/member_signup_processing.feature
@@ -27,7 +27,7 @@ Feature: Processing membership signups
     And my organisation has a company number "08030289"
     And I have a membership id "01010101"
 
-  Scenario: add signups to correct queues
+  Scenario: add signups to invoicing queue
     Given I requested 1 membership at the level called "supporter"
     And I am paying by "invoice"
     And I want to pay on an "annual" basis
@@ -36,7 +36,6 @@ Feature: Processing membership signups
     And the invoice price should be "720"
     And the supporter level should be "Supporter"
     And I should be added to the invoicing queue
-    And I should be added to the capsulecrm queue
     When the signup processor runs
 
   @capsulecrm
@@ -56,7 +55,6 @@ Feature: Processing membership signups
     And the invoice price should be "<price>"
     And the supporter level should be "<level>"
     And I should be added to the invoicing queue
-    And I should be added to the capsulecrm queue
     When the signup processor runs
     Examples:
     | size     | status         | description                                                              | level               | price |
@@ -77,7 +75,6 @@ Feature: Processing membership signups
     And the invoice price should be "720"
     And the supporter level should be "Supporter"
     And I should be added to the invoicing queue
-    And I should be added to the capsulecrm queue
     When the signup processor runs
     Examples:
     | method       | period  | reference | description                                                    |

--- a/features/member_signup_processing.feature
+++ b/features/member_signup_processing.feature
@@ -39,6 +39,12 @@ Feature: Processing membership signups
     And I should be added to the capsulecrm queue
     When the signup processor runs
 
+  @capsulecrm
+  Scenario: add contact details to CapsuleCRM
+    Given I requested 1 membership at the level called "supporter"
+    And the signup processor runs
+    Then my organisation contact details should exist in CapsuleCRM
+
   Scenario Outline: generate correct prices and descriptions
     Given I requested 1 membership at the level called "supporter"
     And my company has a size of "<size>"

--- a/features/processing_individual_signups.feature
+++ b/features/processing_individual_signups.feature
@@ -23,7 +23,6 @@ Feature: Processing individual membership signups
     And the invoice price should be "108"
     And the supporter level should be "Individual"
     And I should be added to the invoicing queue
-    And I should be added to the capsulecrm queue
     When the signup processor runs
 
   @capsulecrm

--- a/features/processing_individual_signups.feature
+++ b/features/processing_individual_signups.feature
@@ -25,3 +25,9 @@ Feature: Processing individual membership signups
     And I should be added to the invoicing queue
     And I should be added to the capsulecrm queue
     When the signup processor runs
+
+  @capsulecrm
+  Scenario: add contact details to CapsuleCRM
+    Given I requested 1 membership at the level called "individual"
+    When the signup processor runs
+    Then my contact details should exist in CapsuleCRM

--- a/features/signup_to_capsule.feature
+++ b/features/signup_to_capsule.feature
@@ -48,6 +48,20 @@ Feature: Create opportunities and tags against organisations in CapsuleCRM
     And that data tag should have the sector "Healthcare"
     And that data tag should have the email "turkleton@acme.com"
 
+  Scenario: attach membership tag to new organisation
+    Given there is no organisation in CapsuleCRM called "ACME widgets Inc."
+    When I sign up via the website
+    Then there should still be just one organisation in CapsuleCRM called "ACME widgets Inc."
+    And that organisation should have a data tag
+    And that data tag should have the type "Membership"
+    And that data tag should have the level "supporter"
+    And that data tag should have the supporter level "Supporter"
+    And that data tag should have the join date 2013-01-01
+    And that data tag should have the membership number "AB1234YZ"
+    And that data tag should have the size "<10"
+    And that data tag should have the sector "Healthcare"
+    And that data tag should have the email "turkleton@acme.com"
+
   Scenario: set company number on existing organisation
     Given there is an existing organisation in CapsuleCRM called "ACME widgets Inc."
     When I sign up via the website

--- a/features/signup_to_capsule.feature
+++ b/features/signup_to_capsule.feature
@@ -17,11 +17,6 @@ Feature: Create opportunities and tags against organisations in CapsuleCRM
     And my company has a size of "<10"
     And my sector is "Healthcare"
 
-  Scenario: wait for Xero to capsule sync
-    Given there is no organisation in CapsuleCRM called "ACME widgets Inc."
-    Then my signup should be requeued for later processing once the contact has synced from Xero
-    When I sign up via the website
-
   Scenario Outline: attach opportunities to existing organisations
     Given there is an existing organisation in CapsuleCRM called "ACME widgets Inc."
     And I requested membership at the level called "<level>"

--- a/features/step_definitions/adding_people_to_capsule_steps.rb
+++ b/features/step_definitions/adding_people_to_capsule_steps.rb
@@ -23,6 +23,7 @@ Given(/^there should still be just one person in CapsuleCRM called "(.*?)" with 
   p.should_not be_nil
   p.first_name.should == person_name.split(" ")[0]
   p.last_name.should == person_name.split(" ")[1]
+  @person ||= p
 end
 
 Given(/^that person is a member$/) do

--- a/features/step_definitions/signup_to_capsule_steps.rb
+++ b/features/step_definitions/signup_to_capsule_steps.rb
@@ -51,3 +51,20 @@ Then /^I should be added to the capsulecrm queue$/ do
   }.compact
   Resque.should_receive(:enqueue).with(SendSignupToCapsule, organization, membership).once
 end
+
+Then(/^my organisation contact details should exist in CapsuleCRM$/) do
+  org = CapsuleCRM::Organisation.find_all(:q => @company).first
+  expect(org.name).to eq(@company)
+  expect(org.emails.first.address).to eq(@invoice_email)
+  @capsule_cleanup << org
+end
+
+Then(/^my contact details should exist in CapsuleCRM$/) do
+  person = CapsuleCRM::Person.find_all(:q => @name).first
+  first_name, last_name = @name.split(" ")
+  expect(person.first_name).to eq(first_name)
+  expect(person.last_name).to eq(last_name)
+
+  expect(person.emails.first.address).to eq(@invoice_email)
+  @capsule_cleanup << person
+end

--- a/features/step_definitions/signup_to_capsule_steps.rb
+++ b/features/step_definitions/signup_to_capsule_steps.rb
@@ -1,21 +1,3 @@
-Then /^my signup should be requeued for later processing once the contact has synced from Xero$/ do
-  organization = {
-    'name' => @company,
-    'company_number' => @company_number,
-    'email' => @email || @invoice_email
-  }
-  membership  = {
-    'product_name'    => @membership_level,
-    'supporter_level' => "Supporter",
-    'id'              => @membership_id.to_s,
-    'join_date'       => Date.today.to_s,
-    'contact_email'   => @email,
-    'size'            => @size,
-    'sector'          => @sector
-  }
-  Resque.should_receive(:enqueue_in).with(1.hour, SendSignupToCapsule, organization, membership).once
-end
-
 When /^I sign up via the website$/ do
   organization = {
     'name' => @company || @contact_name,
@@ -32,24 +14,6 @@ When /^I sign up via the website$/ do
     'sector'          => @sector
   }.compact
   SendSignupToCapsule.perform(organization, membership)
-end
-
-Then /^I should be added to the capsulecrm queue$/ do
-  organization = {
-    'name' => @company,
-    'company_number' => @company_number,
-    'email' => @invoice_email
-  }.compact
-  membership  = {
-    'product_name'     => @membership_level,
-    'supporter_level'  => @supporter_level,
-    'id'               => @membership_id.to_s,
-    'join_date'        => Date.today.to_s,
-    'contact_email'    => @email,
-    'size'             => @size,
-    'sector'           => @sector
-  }.compact
-  Resque.should_receive(:enqueue).with(SendSignupToCapsule, organization, membership).once
 end
 
 Then(/^my organisation contact details should exist in CapsuleCRM$/) do

--- a/fixtures/vcr_cassettes/Add_person_details_to_Capsule_CRM/attach_membership_tag_to_new_person.yml
+++ b/fixtures/vcr_cassettes/Add_person_details_to_Capsule_CRM/attach_membership_tag_to_new_person.yml
@@ -1,0 +1,616 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Arnold%20Rimmer
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 May 2015 13:15:37 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '74'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="0"/>
+    http_version: 
+  recorded_at: Wed, 27 May 2015 13:15:37 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?email=rimmer@jmc.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 May 2015 13:15:38 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '74'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="0"/>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/person
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<person>\n  <about nil=\"true\"/>\n
+        \ <firstName>Arnold</firstName>\n  <lastName>Rimmer</lastName>\n  <title nil=\"true\"/>\n
+        \ <jobTitle nil=\"true\"/>\n  <organisationId nil=\"true\"/>\n  <contacts>\n
+        \   <email>\n      <type nil=\"true\"/>\n      <emailAddress>rimmer@jmc.com</emailAddress>\n
+        \   </email>\n  </contacts>\n</person>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 27 May 2015 13:15:38 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82093208
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82093208/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at individual level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">108</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: HG5646HD</description>\n  <duration type=\"integer\">1</duration>\n
+        \ <durationBasis>YEAR</durationBasis>\n  <expectedCloseDate type=\"date\">2013-01-01</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 27 May 2015 13:15:39 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3251347
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3251347/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 May 2015 13:15:40 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4483180</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82093208/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 27 May 2015 13:15:40 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82093208/tag/Membership
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82093208/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>individual</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 May 2015 13:15:41 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '201'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>79835588</id><tag>Membership</tag><label>Level</label><text>individual</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82093208/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Individual</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 May 2015 13:15:41 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '319'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="2"><customField><id>79835588</id><tag>Membership</tag><label>Level</label><text>individual</text></customField><customField><id>79835589</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Individual</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82093208/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>HG5646HD</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 May 2015 13:15:42 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '422'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="3"><customField><id>79835588</id><tag>Membership</tag><label>Level</label><text>individual</text></customField><customField><id>79835589</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Individual</text></customField><customField><id>79835590</id><tag>Membership</tag><label>ID</label><text>HG5646HD</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82093208/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2013-01-01</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 May 2015 13:15:43 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '541'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="4"><customField><id>79835588</id><tag>Membership</tag><label>Level</label><text>individual</text></customField><customField><id>79835589</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Individual</text></customField><customField><id>79835590</id><tag>Membership</tag><label>ID</label><text>HG5646HD</text></customField><customField><id>79835591</id><tag>Membership</tag><label>Joined</label><date>2013-01-01T00:00:00Z</date></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82093208/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>rimmer@jmc.com</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 May 2015 13:15:43 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '653'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="5"><customField><id>79835588</id><tag>Membership</tag><label>Level</label><text>individual</text></customField><customField><id>79835589</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Individual</text></customField><customField><id>79835590</id><tag>Membership</tag><label>ID</label><text>HG5646HD</text></customField><customField><id>79835591</id><tag>Membership</tag><label>Joined</label><date>2013-01-01T00:00:00Z</date></customField><customField><id>79835592</id><tag>Membership</tag><label>Email</label><text>rimmer@jmc.com</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82093208/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 May 2015 13:15:44 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '762'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="6"><customField><id>79835588</id><tag>Membership</tag><label>Level</label><text>individual</text></customField><customField><id>79835589</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Individual</text></customField><customField><id>79835590</id><tag>Membership</tag><label>ID</label><text>HG5646HD</text></customField><customField><id>79835591</id><tag>Membership</tag><label>Joined</label><date>2013-01-01T00:00:00Z</date></customField><customField><id>79835592</id><tag>Membership</tag><label>Email</label><text>rimmer@jmc.com</text></customField><customField><id>79835593</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?email=rimmer@jmc.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 May 2015 13:15:45 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '472'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><person><id>82093208</id><contacts><email><id>158086408</id><emailAddress>rimmer@jmc.com</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2015-05-27T13:15:39Z</createdOn><updatedOn>2015-05-27T13:15:45Z</updatedOn><firstName>Arnold</firstName><lastName>Rimmer</lastName></person></parties>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82093208/tag
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 May 2015 13:15:45 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82093208/customfield
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 May 2015 13:15:46 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '762'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="6"><customField><id>79835588</id><tag>Membership</tag><label>Level</label><text>individual</text></customField><customField><id>79835589</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Individual</text></customField><customField><id>79835590</id><tag>Membership</tag><label>ID</label><text>HG5646HD</text></customField><customField><id>79835591</id><tag>Membership</tag><label>Joined</label><date>2013-01-01T00:00:00Z</date></customField><customField><id>79835592</id><tag>Membership</tag><label>Email</label><text>rimmer@jmc.com</text></customField><customField><id>79835593</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Create_opportunities_and_tags_against_organisations_in_CapsuleCRM/attach_membership_tag_to_new_organisation.yml
+++ b/fixtures/vcr_cassettes/Create_opportunities_and_tags_against_organisations_in_CapsuleCRM/attach_membership_tag_to_new_organisation.yml
@@ -1,0 +1,704 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=ACME%20widgets%20Inc.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:04 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '74'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="0"/>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=ACME%20widgets%20Inc.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:04 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '74'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="0"/>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/organisation
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<organisation>\n  <about
+        nil=\"true\"/>\n  <name>ACME widgets Inc.</name>\n  <contacts>\n    <email>\n
+        \     <type nil=\"true\"/>\n      <emailAddress>turkleton@acme.com</emailAddress>\n
+        \   </email>\n  </contacts>\n</organisation>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:05 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017502
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017502/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: AB1234YZ</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2013-01-01</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:05 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246978
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246978/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:06 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477907</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017502/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:07 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017502/tag/Membership
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017502/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:07 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '200'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>79792878</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017502/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '317'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="2"><customField><id>79792878</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79792879</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017502/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>AB1234YZ</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '420'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="3"><customField><id>79792878</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79792879</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79792880</id><tag>Membership</tag><label>ID</label><text>AB1234YZ</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017502/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2013-01-01</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:09 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '539'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="4"><customField><id>79792878</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79792879</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79792880</id><tag>Membership</tag><label>ID</label><text>AB1234YZ</text></customField><customField><id>79792881</id><tag>Membership</tag><label>Joined</label><date>2013-01-01T00:00:00Z</date></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017502/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>turkleton@acme.com</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:10 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '655'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="5"><customField><id>79792878</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79792879</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79792880</id><tag>Membership</tag><label>ID</label><text>AB1234YZ</text></customField><customField><id>79792881</id><tag>Membership</tag><label>Joined</label><date>2013-01-01T00:00:00Z</date></customField><customField><id>79792882</id><tag>Membership</tag><label>Email</label><text>turkleton@acme.com</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017502/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>&lt;10</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:10 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '758'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="6"><customField><id>79792878</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79792879</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79792880</id><tag>Membership</tag><label>ID</label><text>AB1234YZ</text></customField><customField><id>79792881</id><tag>Membership</tag><label>Joined</label><date>2013-01-01T00:00:00Z</date></customField><customField><id>79792882</id><tag>Membership</tag><label>Email</label><text>turkleton@acme.com</text></customField><customField><id>79792883</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017502/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:11 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '867'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="7"><customField><id>79792878</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79792879</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79792880</id><tag>Membership</tag><label>ID</label><text>AB1234YZ</text></customField><customField><id>79792881</id><tag>Membership</tag><label>Joined</label><date>2013-01-01T00:00:00Z</date></customField><customField><id>79792882</id><tag>Membership</tag><label>Email</label><text>turkleton@acme.com</text></customField><customField><id>79792883</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79792884</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017502/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:11 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '961'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79792878</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79792879</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79792880</id><tag>Membership</tag><label>ID</label><text>AB1234YZ</text></customField><customField><id>79792881</id><tag>Membership</tag><label>Joined</label><date>2013-01-01T00:00:00Z</date></customField><customField><id>79792882</id><tag>Membership</tag><label>Email</label><text>turkleton@acme.com</text></customField><customField><id>79792883</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79792884</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79792885</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=ACME%20widgets%20Inc.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:12 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '459'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82017502</id><contacts><email><id>157946379</id><emailAddress>turkleton@acme.com</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T12:14:05Z</createdOn><updatedOn>2015-05-26T12:14:12Z</updatedOn><name>ACME
+        widgets Inc.</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017502/tag
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:13 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017502/customfield
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 12:14:13 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '961'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79792878</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79792879</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79792880</id><tag>Membership</tag><label>ID</label><text>AB1234YZ</text></customField><customField><id>79792881</id><tag>Membership</tag><label>Joined</label><date>2013-01-01T00:00:00Z</date></customField><customField><id>79792882</id><tag>Membership</tag><label>Email</label><text>turkleton@acme.com</text></customField><customField><id>79792883</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79792884</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79792885</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Create_opportunities_and_tags_against_organisations_in_CapsuleCRM/attach_opportunities_to_existing_organisations.yml
+++ b/fixtures/vcr_cassettes/Create_opportunities_and_tags_against_organisations_in_CapsuleCRM/attach_opportunities_to_existing_organisations.yml
@@ -1,160 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=ACME%20widgets%20Inc.
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - CapsuleCRM ruby gem
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 12 Dec 2014 11:24:47 GMT
-      Server:
-      - Apache
-      X-Frame-Options:
-      - DENY
-      Set-Cookie:
-      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      Content-Length:
-      - '74'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Content-Type:
-      - ! '*/*;charset=UTF-8'
-    body:
-      encoding: US-ASCII
-      string: <?xml version="1.0" enc<METRICS_API_USERNAME>ng="UTF-8" standalone="yes"?><parties
-        size="0"/>
-    http_version: 
-  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
-- request:
-    method: post
-    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/organisation
-    body:
-      encoding: US-ASCII
-      string: ! "<?xml version=\"1.0\" enc<METRICS_API_USERNAME>ng=\"UTF-8\"?>\n<organisation>\n
-        \ <about nil=\"true\"/>\n  <name>ACME widgets Inc.</name>\n  <contacts/>\n</organisation>\n"
-    headers:
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Fri, 12 Dec 2014 11:24:47 GMT
-      Server:
-      - Apache
-      X-Frame-Options:
-      - DENY
-      Set-Cookie:
-      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      Location:
-      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/72553409
-      Content-Length:
-      - '0'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
-- request:
-    method: get
-    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=ACME%20widgets%20Inc.
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - CapsuleCRM ruby gem
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 12 Dec 2014 11:24:48 GMT
-      Server:
-      - Apache
-      X-Frame-Options:
-      - DENY
-      Set-Cookie:
-      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      Content-Length:
-      - '369'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Content-Type:
-      - ! '*/*;charset=UTF-8'
-    body:
-      encoding: US-ASCII
-      string: <?xml version="1.0" enc<METRICS_API_USERNAME>ng="UTF-8" standalone="yes"?><parties
-        size="1"><organisation><id>72553409</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1418124202/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-12-12T11:24:47Z</createdOn><updatedOn>2014-12-12T11:24:47Z</updatedOn><name>ACME
-        widgets Inc.</name></organisation></parties>
-    http_version: 
-  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
-- request:
-    method: get
-    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=ACME%20widgets%20Inc.
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - CapsuleCRM ruby gem
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 12 Dec 2014 11:24:48 GMT
-      Server:
-      - Apache
-      X-Frame-Options:
-      - DENY
-      Set-Cookie:
-      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      Content-Length:
-      - '369'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Content-Type:
-      - ! '*/*;charset=UTF-8'
-    body:
-      encoding: US-ASCII
-      string: <?xml version="1.0" enc<METRICS_API_USERNAME>ng="UTF-8" standalone="yes"?><parties
-        size="1"><organisation><id>72553409</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1418124202/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-12-12T11:24:47Z</createdOn><updatedOn>2014-12-12T11:24:47Z</updatedOn><name>ACME
-        widgets Inc.</name></organisation></parties>
-    http_version: 
-  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
-- request:
     method: post
     uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/72553409/opportunity
     body:
@@ -608,45 +454,6 @@ http_interactions:
   recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
 - request:
     method: get
-    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=ACME%20widgets%20Inc.
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - CapsuleCRM ruby gem
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Fri, 12 Dec 2014 11:24:56 GMT
-      Server:
-      - Apache
-      X-Frame-Options:
-      - DENY
-      Set-Cookie:
-      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      Content-Length:
-      - '369'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Content-Type:
-      - ! '*/*;charset=UTF-8'
-    body:
-      encoding: US-ASCII
-      string: <?xml version="1.0" enc<METRICS_API_USERNAME>ng="UTF-8" standalone="yes"?><parties
-        size="1"><organisation><id>72553409</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1418124202/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-12-12T11:24:47Z</createdOn><updatedOn>2014-12-12T11:24:55Z</updatedOn><name>ACME
-        widgets Inc.</name></organisation></parties>
-    http_version: 
-  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
-- request:
-    method: get
     uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/72553409/opportunity
     body:
       encoding: US-ASCII
@@ -738,6 +545,779 @@ http_interactions:
     headers:
       Date:
       - Fri, 12 Dec 2014 11:24:57 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=ACME%20widgets%20Inc.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:05 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '74'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="0"/>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/organisation
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<organisation>\n  <about
+        nil=\"true\"/>\n  <name>ACME widgets Inc.</name>\n  <contacts/>\n</organisation>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:06 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017189
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=ACME%20widgets%20Inc.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:06 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '369'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82017189</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T11:59:06Z</createdOn><updatedOn>2015-05-26T11:59:06Z</updatedOn><name>ACME
+        widgets Inc.</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=ACME%20widgets%20Inc.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:07 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '369'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82017189</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T11:59:06Z</createdOn><updatedOn>2015-05-26T11:59:06Z</updatedOn><name>ACME
+        widgets Inc.</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017189/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: AB1234YZ</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2013-01-01</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:07 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246927
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246927/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477805</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017189/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017189/tag/Membership
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017189/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:09 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '200'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>79792636</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017189/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:09 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '317'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="2"><customField><id>79792636</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79792637</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017189/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>AB1234YZ</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:10 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '420'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="3"><customField><id>79792636</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79792637</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79792638</id><tag>Membership</tag><label>ID</label><text>AB1234YZ</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017189/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2013-01-01</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:12 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '539'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="4"><customField><id>79792636</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79792637</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79792638</id><tag>Membership</tag><label>ID</label><text>AB1234YZ</text></customField><customField><id>79792639</id><tag>Membership</tag><label>Joined</label><date>2013-01-01T00:00:00Z</date></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017189/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>turkleton@acme.com</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:13 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '655'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="5"><customField><id>79792636</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79792637</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79792638</id><tag>Membership</tag><label>ID</label><text>AB1234YZ</text></customField><customField><id>79792639</id><tag>Membership</tag><label>Joined</label><date>2013-01-01T00:00:00Z</date></customField><customField><id>79792640</id><tag>Membership</tag><label>Email</label><text>turkleton@acme.com</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017189/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>&lt;10</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:14 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '758'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="6"><customField><id>79792636</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79792637</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79792638</id><tag>Membership</tag><label>ID</label><text>AB1234YZ</text></customField><customField><id>79792639</id><tag>Membership</tag><label>Joined</label><date>2013-01-01T00:00:00Z</date></customField><customField><id>79792640</id><tag>Membership</tag><label>Email</label><text>turkleton@acme.com</text></customField><customField><id>79792641</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017189/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:14 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '867'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="7"><customField><id>79792636</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79792637</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79792638</id><tag>Membership</tag><label>ID</label><text>AB1234YZ</text></customField><customField><id>79792639</id><tag>Membership</tag><label>Joined</label><date>2013-01-01T00:00:00Z</date></customField><customField><id>79792640</id><tag>Membership</tag><label>Email</label><text>turkleton@acme.com</text></customField><customField><id>79792641</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79792642</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017189/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:15 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '961'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79792636</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79792637</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79792638</id><tag>Membership</tag><label>ID</label><text>AB1234YZ</text></customField><customField><id>79792639</id><tag>Membership</tag><label>Joined</label><date>2013-01-01T00:00:00Z</date></customField><customField><id>79792640</id><tag>Membership</tag><label>Email</label><text>turkleton@acme.com</text></customField><customField><id>79792641</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79792642</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79792643</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=ACME%20widgets%20Inc.
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:16 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '369'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82017189</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T11:59:06Z</createdOn><updatedOn>2015-05-26T11:59:16Z</updatedOn><name>ACME
+        widgets Inc.</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017189/opportunity
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:16 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '679'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: ! '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><opportunities
+        size="1"><opportunity><id>3246927</id><name>Membership at supporter level</name><description>Membership
+        #: AB1234YZ</description><partyId>82017189</partyId><currency>GBP</currency><value>60.00</value><durationBasis>MONTH</durationBasis><duration>12</duration><expectedCloseDate>2013-01-01T00:00:00Z</expectedCloseDate><actualCloseDate>2015-05-26T00:00:00Z</actualCloseDate><milestoneId>154049</milestoneId><milestone>Invoiced</milestone><probability>100</probability><owner><CAPSULECRM_DEFAULT_OWNER></owner><createdOn>2015-05-26T11:59:08Z</createdOn><updatedOn>2015-05-26T11:59:08Z</updatedOn></opportunity></opportunities>'
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246927/customfield
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:17 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477805</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 01 Jan 2013 14:35:00 GMT
+- request:
+    method: delete
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82017189
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:59:17 GMT
       Server:
       - Apache
       X-Frame-Options:

--- a/fixtures/vcr_cassettes/Processing_individual_membership_signups/add_contact_details_to_CapsuleCRM.yml
+++ b/fixtures/vcr_cassettes/Processing_individual_membership_signups/add_contact_details_to_CapsuleCRM.yml
@@ -1,352 +1,8 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://api.xero.com/api.xro/2.0/Contacts?where=Name%20==%20%22Existing%20Company%20Inc.%22
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Charset:
-      - utf-8
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - OAuth gem v0.4.7
-      Authorization:
-      - OAuth oauth_consumer_key="<XERO_CONSUMER_KEY>", oauth_nonce="QOPqhwbBrJ6o1i5KHiJeLVtefTAMTUzqDt9DXw5HY",
-        oauth_signature="lmVu3vjDj4Vd%2B1H7yKxjp5zRKh8CeOfjHj31W%2FYnFazPjyrGwMxHlRimgN7Du4BpW7uZprl2%2FQGtM0YVsNKVbYrAC8r4baxnYfMfgaIyWmcDrBAGydX58M3pmVlOahbn6TMEKQfGKhAj%2BcFomlt8aLxvRYedsDh1TETtVGt8Pss%3D",
-        oauth_signature_method="RSA-SHA1", oauth_timestamp="1418222335", oauth_token="<XERO_CONSUMER_KEY>",
-        oauth_version="1.0"
-  response:
-    status:
-      code: 401
-      message: Unauthorized
-    headers:
-      Cache-Control:
-      - private
-      Content-Type:
-      - text/html; charset=utf-8
-      Www-Authenticate:
-      - OAuth Realm="86.191.38.119"
-      X-S:
-      - 445759-O1VMAP02
-      Strict-Transport-Security:
-      - max-age=31536000
-      Date:
-      - Wed, 10 Dec 2014 14:38:56 GMT
-      Content-Length:
-      - '118'
-    body:
-      encoding: US-ASCII
-      string: oauth_problem=token_rejected&oauth_problem_advice=The%20organisation%20for%20this%20access%20token%20is%20not%20active
-    http_version: 
-  recorded_at: Wed, 10 Dec 2014 14:38:56 GMT
-- request:
-    method: get
-    uri: https://api.xero.com/api.xro/2.0/Contacts
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Charset:
-      - utf-8
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - OAuth gem v0.4.7
-      Authorization:
-      - OAuth oauth_consumer_key="<XERO_CONSUMER_KEY>", oauth_nonce="l2wMZXZBPThzYKZlTKHseAfYTqw2auo0P5xwNV1uOQ",
-        oauth_signature="F3y8BvvoteLVqp3r32pTCB886reG3WBRtMv8k%2BmAN2iqn2k4hlNSSzUv1q1SmnsOTd6k33VBBYzr4UE8vTkqpn4u3VCz29ldR1%2BYyuf1tEr9TxWVseWaEUwzW%2FLFmFbxl872s%2FFImY131UnxpdzsvXaR1XQv1GVrmE%2BjLwcrB7g%3D",
-        oauth_signature_method="RSA-SHA1", oauth_timestamp="1418223294", oauth_token="<XERO_CONSUMER_KEY>",
-        oauth_version="1.0"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - private
-      Content-Type:
-      - text/xml; charset=utf-8
-      Www-Authenticate:
-      - OAuth Realm="api.xero.com"
-      X-S:
-      - 445761-O1VMAP04
-      Strict-Transport-Security:
-      - max-age=31536000
-      Date:
-      - Wed, 10 Dec 2014 14:54:55 GMT
-      Content-Length:
-      - '307'
-    body:
-      encoding: US-ASCII
-      string: ! "<Response xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n
-        \ <Id>11e531e8-6a59-4bb0-950e-26e3ecbfe249</Id>\r\n  <Status>OK</Status>\r\n
-        \ <ProviderName>Duck a dill dill dill</ProviderName>\r\n  <DateTimeUTC>2014-12-10T14:54:56.0319529Z</DateTimeUTC>\r\n</Response>"
-    http_version: 
-  recorded_at: Wed, 10 Dec 2014 14:54:55 GMT
-- request:
     method: put
-    uri: https://api.xero.com/api.xro/2.0/Contacts
-    body:
-      encoding: US-ASCII
-      string: xml=%3CContact%3E%0A%20%20%3CName%3EJoe%20Nerd%3C%2FName%3E%0A%3C%2FContact%3E%0A
-    headers:
-      Charset:
-      - utf-8
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - OAuth gem v0.4.7
-      Content-Length:
-      - '0'
-      Authorization:
-      - OAuth oauth_consumer_key="<XERO_CONSUMER_KEY>", oauth_nonce="YHgsEgIXFrSFV38yjppJO99KHS1BRWXtXe98XMoIpY",
-        oauth_signature="oKypUxjL30AvWAxKiOOgAtKoN9nM5WLzHtPMgc95eUpuf7J%2BainAMgnjyWxKBlB5UU3%2BdcnsqkBxcWLJtdMndGSmzaflo2vcwBPVxRdFzpqKPv8WJnmkI%2FZXnswy7wheG12PK8RddMEmDnSYRyS9KUixEPlJZEKu%2FvpGGhjLv%2Fs%3D",
-        oauth_signature_method="RSA-SHA1", oauth_timestamp="1418225783", oauth_token="<XERO_CONSUMER_KEY>",
-        oauth_version="1.0"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - private
-      Content-Type:
-      - text/xml; charset=utf-8
-      Www-Authenticate:
-      - OAuth Realm="api.xero.com"
-      X-S:
-      - 445759-O1VMAP02
-      Strict-Transport-Security:
-      - max-age=31536000
-      Date:
-      - Wed, 10 Dec 2014 15:36:25 GMT
-      Content-Length:
-      - '1186'
-    body:
-      encoding: US-ASCII
-      string: ! "<Response xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n
-        \ <Id>eeb132c9-93ee-4647-a26f-f858da8bc481</Id>\r\n  <Status>OK</Status>\r\n
-        \ <ProviderName>Duck a dill dill dill</ProviderName>\r\n  <DateTimeUTC>2014-12-10T15:36:25.3769403Z</DateTimeUTC>\r\n
-        \ <Contacts>\r\n    <Contact>\r\n      <ContactID>36cc2e69-a96d-486c-90ad-8da2231beac7</ContactID>\r\n
-        \     <ContactStatus>ACTIVE</ContactStatus>\r\n      <Name>Joe Nerd</Name>\r\n
-        \     <Addresses>\r\n        <Address>\r\n          <AddressType>POBOX</AddressType>\r\n
-        \       </Address>\r\n        <Address>\r\n          <AddressType>STREET</AddressType>\r\n
-        \       </Address>\r\n      </Addresses>\r\n      <Phones>\r\n        <Phone>\r\n
-        \         <PhoneType>MOBILE</PhoneType>\r\n        </Phone>\r\n        <Phone>\r\n
-        \         <PhoneType>FAX</PhoneType>\r\n        </Phone>\r\n        <Phone>\r\n
-        \         <PhoneType>DDI</PhoneType>\r\n        </Phone>\r\n        <Phone>\r\n
-        \         <PhoneType>DEFAULT</PhoneType>\r\n        </Phone>\r\n      </Phones>\r\n
-        \     <UpdatedDateUTC>2014-12-10T15:36:25.347</UpdatedDateUTC>\r\n      <IsSupplier>false</IsSupplier>\r\n
-        \     <IsCustomer>false</IsCustomer>\r\n    </Contact>\r\n  </Contacts>\r\n</Response>"
-    http_version: 
-  recorded_at: Wed, 10 Dec 2014 15:36:25 GMT
-- request:
-    method: get
-    uri: https://api.xero.com/api.xro/2.0/Contacts?where=Name%20==%20%22Joe%20Nerd%22
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Charset:
-      - utf-8
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - OAuth gem v0.4.7
-      Authorization:
-      - OAuth oauth_consumer_key="<XERO_CONSUMER_KEY>", oauth_nonce="eSqHoI5sh5C0UpKea9LaBZidKNKelqHQepflhFTPM",
-        oauth_signature="HzNaNEb0niakduzXjrmzRmoue9ejTfqmCz92Vz5DwM4jmJB%2Bil7p%2BWBWpPuqShYnwyWFX2D433YunXVq5cLyQIiS%2B%2FFz5foujWsDHIdtho3WCPm8S8R4SJloEIm4nDk9Ni%2F3dKtLX16T9wadmvd0Zb0NmEJoygTxxQEZp%2FYEGuQ%3D",
-        oauth_signature_method="RSA-SHA1", oauth_timestamp="1418228295", oauth_token="<XERO_CONSUMER_KEY>",
-        oauth_version="1.0"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - private
-      Content-Type:
-      - text/xml; charset=utf-8
-      Www-Authenticate:
-      - OAuth Realm="api.xero.com"
-      X-S:
-      - 445758-O1VMAP01
-      Strict-Transport-Security:
-      - max-age=31536000
-      Date:
-      - Wed, 10 Dec 2014 16:18:15 GMT
-      Content-Length:
-      - '1231'
-    body:
-      encoding: US-ASCII
-      string: ! "<Response xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n
-        \ <Id>b3714ee3-c42f-4b5c-95fc-559700c10721</Id>\r\n  <Status>OK</Status>\r\n
-        \ <ProviderName>Duck a dill dill dill</ProviderName>\r\n  <DateTimeUTC>2014-12-10T16:18:16.098465Z</DateTimeUTC>\r\n
-        \ <Contacts>\r\n    <Contact>\r\n      <ContactID>36cc2e69-a96d-486c-90ad-8da2231beac7</ContactID>\r\n
-        \     <ContactStatus>ACTIVE</ContactStatus>\r\n      <Name>Joe Nerd</Name>\r\n
-        \     <Addresses>\r\n        <Address>\r\n          <AddressType>POBOX</AddressType>\r\n
-        \       </Address>\r\n        <Address>\r\n          <AddressType>STREET</AddressType>\r\n
-        \       </Address>\r\n      </Addresses>\r\n      <Phones>\r\n        <Phone>\r\n
-        \         <PhoneType>DDI</PhoneType>\r\n        </Phone>\r\n        <Phone>\r\n
-        \         <PhoneType>DEFAULT</PhoneType>\r\n        </Phone>\r\n        <Phone>\r\n
-        \         <PhoneType>FAX</PhoneType>\r\n        </Phone>\r\n        <Phone>\r\n
-        \         <PhoneType>MOBILE</PhoneType>\r\n        </Phone>\r\n      </Phones>\r\n
-        \     <UpdatedDateUTC>2014-12-10T15:36:25.347</UpdatedDateUTC>\r\n      <IsSupplier>false</IsSupplier>\r\n
-        \     <IsCustomer>false</IsCustomer>\r\n      <HasAttachments>false</HasAttachments>\r\n
-        \   </Contact>\r\n  </Contacts>\r\n</Response>"
-    http_version: 
-  recorded_at: Wed, 10 Dec 2014 16:18:16 GMT
-- request:
-    method: get
-    uri: https://api.xero.com/api.xro/2.0/Contacts?where=Name%20==%20%22Joe%20Nerd%22
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Charset:
-      - utf-8
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - OAuth gem v0.4.7
-      Authorization:
-      - OAuth oauth_consumer_key="<XERO_CONSUMER_KEY>", oauth_nonce="3qMtiYWnENRp16LoHQupgBlU5Zj6GtKfH4NpNaX4L8",
-        oauth_signature="FTHKbFbinB3%2FIs6Y9ykvsPGkpuZcRVGkBOVBap9fVsG23W3cdPQQfszTeN4jgnwfcyAlHhmRa%2F%2BfU2hwrqCNonYyi8MSWzpgAbvqBm%2FOOJxuxntAwojB5ORNcHJz80n2m1Q8jW%2FBftJ%2BmXSxGTYFYevjaSQAkafSqgjyqL7gtB0%3D",
-        oauth_signature_method="RSA-SHA1", oauth_timestamp="1418228941", oauth_token="<XERO_CONSUMER_KEY>",
-        oauth_version="1.0"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - private
-      Content-Type:
-      - text/xml; charset=utf-8
-      Www-Authenticate:
-      - OAuth Realm="api.xero.com"
-      X-S:
-      - 445761-O1VMAP04
-      Strict-Transport-Security:
-      - max-age=31536000
-      Date:
-      - Wed, 10 Dec 2014 16:29:02 GMT
-      Content-Length:
-      - '1230'
-    body:
-      encoding: US-ASCII
-      string: ! "<Response xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n
-        \ <Id>5bd79dc4-2454-4e92-87a9-8ed43a5814ca</Id>\r\n  <Status>OK</Status>\r\n
-        \ <ProviderName>Duck a dill dill dill</ProviderName>\r\n  <DateTimeUTC>2014-12-10T16:29:02.48033Z</DateTimeUTC>\r\n
-        \ <Contacts>\r\n    <Contact>\r\n      <ContactID>36cc2e69-a96d-486c-90ad-8da2231beac7</ContactID>\r\n
-        \     <ContactStatus>ACTIVE</ContactStatus>\r\n      <Name>Joe Nerd</Name>\r\n
-        \     <Addresses>\r\n        <Address>\r\n          <AddressType>POBOX</AddressType>\r\n
-        \       </Address>\r\n        <Address>\r\n          <AddressType>STREET</AddressType>\r\n
-        \       </Address>\r\n      </Addresses>\r\n      <Phones>\r\n        <Phone>\r\n
-        \         <PhoneType>DDI</PhoneType>\r\n        </Phone>\r\n        <Phone>\r\n
-        \         <PhoneType>DEFAULT</PhoneType>\r\n        </Phone>\r\n        <Phone>\r\n
-        \         <PhoneType>FAX</PhoneType>\r\n        </Phone>\r\n        <Phone>\r\n
-        \         <PhoneType>MOBILE</PhoneType>\r\n        </Phone>\r\n      </Phones>\r\n
-        \     <UpdatedDateUTC>2014-12-10T15:36:25.347</UpdatedDateUTC>\r\n      <IsSupplier>false</IsSupplier>\r\n
-        \     <IsCustomer>false</IsCustomer>\r\n      <HasAttachments>false</HasAttachments>\r\n
-        \   </Contact>\r\n  </Contacts>\r\n</Response>"
-    http_version: 
-  recorded_at: Wed, 10 Dec 2014 16:29:02 GMT
-- request:
-    method: get
-    uri: https://api.xero.com/api.xro/2.0/Invoices?where=Contact.ContactID%20=%20GUID(%2236cc2e69-a96d-486c-90ad-8da2231beac7%22)%20AND%20Status%20!=%20%22DELETED%22
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Charset:
-      - utf-8
-      Accept:
-      - ! '*/*'
-      User-Agent:
-      - OAuth gem v0.4.7
-      Authorization:
-      - OAuth oauth_consumer_key="<XERO_CONSUMER_KEY>", oauth_nonce="n48MxpFmH9mug0KFxK2STlLtGR9UcyN1SDLKo3M6uZ8",
-        oauth_signature="VxNbitaso1e34ULSIEaK2reH%2FKsgzKhxV7nfrG1QPOlZTxWTV7lwD959dvtPrxc1y7MdYsQ1r8FLkeeAz0CTiVk0HDQm7G8kdehFCon2uffcFG6FxVvNRh2rp3JGheljjvtLE0qm%2F1PH%2F0tLvzE5k2kD2xHAnqEbEYDjHrlplH8%3D",
-        oauth_signature_method="RSA-SHA1", oauth_timestamp="1418228942", oauth_token="<XERO_CONSUMER_KEY>",
-        oauth_version="1.0"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - private
-      Content-Type:
-      - text/xml; charset=utf-8
-      Www-Authenticate:
-      - OAuth Realm="api.xero.com"
-      X-S:
-      - 445761-O1VMAP04
-      Strict-Transport-Security:
-      - max-age=31536000
-      Date:
-      - Wed, 10 Dec 2014 16:29:03 GMT
-      Content-Length:
-      - '306'
-    body:
-      encoding: US-ASCII
-      string: ! "<Response xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n
-        \ <Id>1240d41a-1cb3-4936-b5c5-2e5f7a4c886b</Id>\r\n  <Status>OK</Status>\r\n
-        \ <ProviderName>Duck a dill dill dill</ProviderName>\r\n  <DateTimeUTC>2014-12-10T16:29:03.728354Z</DateTimeUTC>\r\n</Response>"
-    http_version: 
-  recorded_at: Wed, 10 Dec 2014 16:29:03 GMT
-- request:
-    method: post
-    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/person
-    body:
-      encoding: US-ASCII
-      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<person>\n  <about nil=\"true\"/>\n
-        \ <firstName>Joe</firstName>\n  <lastName>Nerd</lastName>\n  <title nil=\"true\"/>\n
-        \ <jobTitle nil=\"true\"/>\n  <organisationId nil=\"true\"/>\n  <contacts>\n
-        \   <email>\n      <type nil=\"true\"/>\n      <emailAddress>finance@nerd.eg</emailAddress>\n
-        \   </email>\n  </contacts>\n</person>\n"
-    headers:
-      User-Agent:
-      - CapsuleCRM ruby gem
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Tue, 26 May 2015 11:01:31 GMT
-      Server:
-      - Apache
-      X-Frame-Options:
-      - DENY
-      Set-Cookie:
-      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      Location:
-      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82014022
-      Content-Length:
-      - '0'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-    body:
-      encoding: US-ASCII
-      string: ''
-    http_version: 
-  recorded_at: Tue, 26 May 2015 11:01:31 GMT
-- request:
-    method: put
-    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246698/customfields
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246699/customfields
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
@@ -363,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 26 May 2015 11:01:32 GMT
+      - Tue, 26 May 2015 11:01:39 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -383,12 +39,12 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
-        size="1"><customField><id>4477445</id><label>Type</label><text>Membership</text></customField></customFields>
+        size="1"><customField><id>4477446</id><label>Type</label><text>Membership</text></customField></customFields>
     http_version: 
-  recorded_at: Tue, 26 May 2015 11:01:33 GMT
+  recorded_at: Tue, 26 May 2015 11:01:39 GMT
 - request:
     method: put
-    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246704/customfields
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246705/customfields
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
@@ -405,7 +61,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 26 May 2015 11:02:41 GMT
+      - Tue, 26 May 2015 11:02:47 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -425,12 +81,66 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
-        size="1"><customField><id>4477455</id><label>Type</label><text>Membership</text></customField></customFields>
+        size="1"><customField><id>4477456</id><label>Type</label><text>Membership</text></customField></customFields>
     http_version: 
-  recorded_at: Tue, 26 May 2015 11:02:41 GMT
+  recorded_at: Tue, 26 May 2015 11:02:47 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:02:52 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="25"><organisation><id>67713003</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T13:50:02Z</createdOn><updatedOn>2014-09-17T14:10:23Z</updatedOn><name>Bob's
+        Exotic Animals</name></organisation><organisation><id>67714053</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T14:19:41Z</createdOn><updatedOn>2014-09-17T14:21:08Z</updatedOn><name>Clive</name></organisation><organisation><id>61373912</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:06Z</createdOn><updatedOn>2014-05-16T14:16:06Z</updatedOn><name>company
+        A</name></organisation><organisation><id>61373993</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:13Z</createdOn><updatedOn>2014-05-16T14:16:13Z</updatedOn><name>company
+        B</name></organisation><organisation><id>61374051</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:18Z</createdOn><updatedOn>2014-05-16T14:16:18Z</updatedOn><name>company
+        C</name></organisation><organisation><id>61374058</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:24Z</createdOn><updatedOn>2014-05-16T14:16:24Z</updatedOn><name>company
+        D</name></organisation><organisation><id>61374067</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:31Z</createdOn><updatedOn>2014-05-16T14:16:31Z</updatedOn><name>company
+        E</name></organisation><organisation><id>61374071</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:37Z</createdOn><updatedOn>2014-05-16T14:16:37Z</updatedOn><name>company
+        F</name></organisation><organisation><id>61374074</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:42Z</createdOn><updatedOn>2014-05-16T14:16:42Z</updatedOn><name>company
+        G</name></organisation><person><id>37121194</id><contacts><email><id>70968278</id><emailAddress>tech@theodi.org</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2013-03-01T11:58:32Z</createdOn><updatedOn>2013-03-01T11:58:32Z</updatedOn><firstName>Default</firstName><lastName>User</lastName></person><organisation><id>67713852</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T14:12:41Z</createdOn><updatedOn>2014-09-17T14:13:00Z</updatedOn><name>Fish</name></organisation><organisation><id>67706736</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T13:07:05Z</createdOn><updatedOn>2014-09-17T14:05:51Z</updatedOn><name>Flibble
+        Inc</name></organisation><person><id>82014022</id><contacts><email><id>157939461</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2015-05-26T11:01:32Z</createdOn><updatedOn>2015-05-26T11:01:37Z</updatedOn><firstName>Joe</firstName><lastName>Nerd</lastName></person><organisation><id>67713970</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T14:16:53Z</createdOn><updatedOn>2014-09-17T14:17:15Z</updatedOn><name>Met
+        Office</name></organisation><organisation><id>82006321</id><contacts><email><id>157929487</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T10:49:24Z</createdOn><updatedOn>2015-05-26T10:49:42Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation><organisation><id>67712662</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T13:38:26Z</createdOn><updatedOn>2014-09-17T13:44:13Z</updatedOn><name>Ping</name></organisation><organisation><id>52925184</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2013-12-16T08:54:56Z</createdOn><updatedOn>2014-08-28T08:14:19Z</updatedOn><name>Satan
+        Claus</name></organisation><organisation><id>67708912</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T13:14:11Z</createdOn><updatedOn>2014-09-17T13:17:53Z</updatedOn><name>Spong</name></organisation><person><id>36614070</id><contacts><email><id>69924901</id><emailAddress>tech@theodi.org</emailAddress></email></contacts><pictureURL>https://secure.gravatar.com/avatar/684cd479441406753cb68c1f125e7145?s=70&amp;r=G</pictureURL><createdOn>2013-02-19T15:25:32Z</createdOn><updatedOn>2013-03-01T11:58:50Z</updatedOn><firstName>Tech</firstName><lastName>Team</lastName></person><person><id>65867769</id><contacts><email><id>126705708</id><type>Work</type><emailAddress>turkleton@acme.com</emailAddress></email><phone><id>126705709</id><type>Work</type><phoneNumber>+44
+        1738 494032</phoneNumber></phone></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2014-08-12T08:55:48Z</createdOn><updatedOn>2014-08-12T08:55:51Z</updatedOn><firstName>Turk</firstName><lastName>Turkleton</lastName><jobTitle>CTO</jobTitle></person><person><id>65867773</id><contacts><email><id>126705714</id><type>Work</type><emailAddress>turkleton@acme.com</emailAddress></email><phone><id>126705715</id><type>Work</type><phoneNumber>+44
+        1738 494032</phoneNumber></phone></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2014-08-12T08:55:54Z</createdOn><updatedOn>2014-08-12T08:55:58Z</updatedOn><firstName>Turk</firstName><lastName>Turkleton</lastName><jobTitle>CTO</jobTitle></person><person><id>65867781</id><contacts><email><id>126705729</id><type>Work</type><emailAddress>turkleton@acme.com</emailAddress></email><phone><id>126705730</id><type>Work</type><phoneNumber>+44
+        1738 494032</phoneNumber></phone></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2014-08-12T08:56:07Z</createdOn><updatedOn>2014-08-12T08:56:11Z</updatedOn><firstName>Turk</firstName><lastName>Turkleton</lastName><jobTitle>CTO</jobTitle></person><person><id>65867787</id><contacts><email><id>126705737</id><type>Work</type><emailAddress>turkleton@acme.com</emailAddress></email><phone><id>126705738</id><type>Work</type><phoneNumber>+44
+        1738 494032</phoneNumber></phone></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2014-08-12T08:56:14Z</createdOn><updatedOn>2014-08-12T08:56:18Z</updatedOn><firstName>Turk</firstName><lastName>Turkleton</lastName><jobTitle>CTO</jobTitle></person><person><id>65867790</id><contacts><email><id>126705741</id><type>Work</type><emailAddress>turkleton@acme.com</emailAddress></email><phone><id>126705742</id><type>Work</type><phoneNumber>+44
+        1738 494032</phoneNumber></phone></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2014-08-12T08:56:20Z</createdOn><updatedOn>2014-08-12T08:56:24Z</updatedOn><firstName>Turk</firstName><lastName>Turkleton</lastName><jobTitle>CTO</jobTitle></person><organisation><id>67710108</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T13:22:03Z</createdOn><updatedOn>2014-09-17T13:23:10Z</updatedOn><name>WAT</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 11:02:52 GMT
 - request:
     method: put
-    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246712/customfields
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246869/customfields
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
@@ -447,7 +157,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 26 May 2015 11:03:30 GMT
+      - Tue, 26 May 2015 11:43:01 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -467,12 +177,12 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
-        size="1"><customField><id>4477462</id><label>Type</label><text>Membership</text></customField></customFields>
+        size="1"><customField><id>4477734</id><label>Type</label><text>Membership</text></customField></customFields>
     http_version: 
-  recorded_at: Tue, 26 May 2015 11:03:30 GMT
+  recorded_at: Tue, 26 May 2015 11:43:01 GMT
 - request:
     method: put
-    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246867/customfields
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246871/customfields
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
@@ -489,7 +199,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 26 May 2015 11:42:55 GMT
+      - Tue, 26 May 2015 11:43:46 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -509,51 +219,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
-        size="1"><customField><id>4477733</id><label>Type</label><text>Membership</text></customField></customFields>
+        size="1"><customField><id>4477738</id><label>Type</label><text>Membership</text></customField></customFields>
     http_version: 
-  recorded_at: Tue, 26 May 2015 11:42:55 GMT
-- request:
-    method: put
-    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246870/customfields
-    body:
-      encoding: US-ASCII
-      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
-        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
-        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
-    headers:
-      User-Agent:
-      - CapsuleCRM ruby gem
-      Content-Type:
-      - text/xml
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 26 May 2015 11:43:40 GMT
-      Server:
-      - Apache
-      X-Frame-Options:
-      - DENY
-      Set-Cookie:
-      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
-      Content-Length:
-      - '178'
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Content-Type-Options:
-      - nosniff
-      Strict-Transport-Security:
-      - max-age=31536000
-      Content-Type:
-      - ! '*/*;charset=UTF-8'
-    body:
-      encoding: US-ASCII
-      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
-        size="1"><customField><id>4477737</id><label>Type</label><text>Membership</text></customField></customFields>
-    http_version: 
-  recorded_at: Tue, 26 May 2015 11:43:40 GMT
+  recorded_at: Tue, 26 May 2015 11:43:46 GMT
 - request:
     method: get
     uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?email=finance@nerd.eg
@@ -569,7 +237,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 26 May 2015 11:44:17 GMT
+      - Tue, 26 May 2015 11:44:23 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -591,7 +259,7 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="2"><organisation><id>82006321</id><contacts><email><id>157929487</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T10:49:24Z</createdOn><updatedOn>2015-05-26T10:49:42Z</updatedOn><name>Nerd
         Enterprises Inc</name></organisation><person><id>82014022</id><contacts><email><id>157939461</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2015-05-26T11:01:32Z</createdOn><updatedOn>2015-05-26T11:01:37Z</updatedOn><firstName>Joe</firstName><lastName>Nerd</lastName></person></parties>
     http_version: 
-  recorded_at: Tue, 26 May 2015 11:44:17 GMT
+  recorded_at: Tue, 26 May 2015 11:44:23 GMT
 - request:
     method: post
     uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82014022/opportunity
@@ -614,7 +282,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 26 May 2015 11:44:17 GMT
+      - Tue, 26 May 2015 11:44:23 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -622,7 +290,7 @@ http_interactions:
       Set-Cookie:
       - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
       Location:
-      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246876
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246877
       Content-Length:
       - '0'
       X-Xss-Protection:
@@ -635,10 +303,10 @@ http_interactions:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Tue, 26 May 2015 11:44:17 GMT
+  recorded_at: Tue, 26 May 2015 11:44:23 GMT
 - request:
     method: put
-    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246876/customfields
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246877/customfields
     body:
       encoding: US-ASCII
       string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
@@ -655,7 +323,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 26 May 2015 11:44:18 GMT
+      - Tue, 26 May 2015 11:44:24 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -675,9 +343,9 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
-        size="1"><customField><id>4477745</id><label>Type</label><text>Membership</text></customField></customFields>
+        size="1"><customField><id>4477746</id><label>Type</label><text>Membership</text></customField></customFields>
     http_version: 
-  recorded_at: Tue, 26 May 2015 11:44:18 GMT
+  recorded_at: Tue, 26 May 2015 11:44:24 GMT
 - request:
     method: post
     uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82014022/tag/Membership
@@ -696,7 +364,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 26 May 2015 11:44:18 GMT
+      - Tue, 26 May 2015 11:44:24 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -717,7 +385,7 @@ http_interactions:
       encoding: US-ASCII
       string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
     http_version: 
-  recorded_at: Tue, 26 May 2015 11:44:18 GMT
+  recorded_at: Tue, 26 May 2015 11:44:25 GMT
 - request:
     method: put
     uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82014022/customfields
@@ -737,7 +405,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 26 May 2015 11:44:19 GMT
+      - Tue, 26 May 2015 11:44:25 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -760,7 +428,7 @@ http_interactions:
         size="6"><customField><id>79789957</id><tag>Membership</tag><label>Level</label><text>individual</text></customField><customField><id>79789982</id><tag>Membership</tag><label>Supporter
         Level</label><text>Individual</text></customField><customField><id>79790020</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79790052</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79790080</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79790111</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField></customFields>
     http_version: 
-  recorded_at: Tue, 26 May 2015 11:44:19 GMT
+  recorded_at: Tue, 26 May 2015 11:44:25 GMT
 - request:
     method: put
     uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82014022/customfields
@@ -780,7 +448,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 26 May 2015 11:44:19 GMT
+      - Tue, 26 May 2015 11:44:26 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -803,7 +471,7 @@ http_interactions:
         size="6"><customField><id>79789957</id><tag>Membership</tag><label>Level</label><text>individual</text></customField><customField><id>79789982</id><tag>Membership</tag><label>Supporter
         Level</label><text>Individual</text></customField><customField><id>79790020</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79790052</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79790080</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79790111</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField></customFields>
     http_version: 
-  recorded_at: Tue, 26 May 2015 11:44:20 GMT
+  recorded_at: Tue, 26 May 2015 11:44:26 GMT
 - request:
     method: put
     uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82014022/customfields
@@ -823,7 +491,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 26 May 2015 11:44:20 GMT
+      - Tue, 26 May 2015 11:44:26 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -846,7 +514,7 @@ http_interactions:
         size="6"><customField><id>79789957</id><tag>Membership</tag><label>Level</label><text>individual</text></customField><customField><id>79789982</id><tag>Membership</tag><label>Supporter
         Level</label><text>Individual</text></customField><customField><id>79790020</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79790052</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79790080</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79790111</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField></customFields>
     http_version: 
-  recorded_at: Tue, 26 May 2015 11:44:20 GMT
+  recorded_at: Tue, 26 May 2015 11:44:26 GMT
 - request:
     method: put
     uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82014022/customfields
@@ -866,7 +534,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 26 May 2015 11:44:21 GMT
+      - Tue, 26 May 2015 11:44:27 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -889,7 +557,7 @@ http_interactions:
         size="6"><customField><id>79789957</id><tag>Membership</tag><label>Level</label><text>individual</text></customField><customField><id>79789982</id><tag>Membership</tag><label>Supporter
         Level</label><text>Individual</text></customField><customField><id>79790020</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79790052</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79790080</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79790111</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField></customFields>
     http_version: 
-  recorded_at: Tue, 26 May 2015 11:44:21 GMT
+  recorded_at: Tue, 26 May 2015 11:44:27 GMT
 - request:
     method: put
     uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82014022/customfields
@@ -909,7 +577,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 26 May 2015 11:44:21 GMT
+      - Tue, 26 May 2015 11:44:27 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -932,7 +600,7 @@ http_interactions:
         size="6"><customField><id>79789957</id><tag>Membership</tag><label>Level</label><text>individual</text></customField><customField><id>79789982</id><tag>Membership</tag><label>Supporter
         Level</label><text>Individual</text></customField><customField><id>79790020</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79790052</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79790080</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79790111</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField></customFields>
     http_version: 
-  recorded_at: Tue, 26 May 2015 11:44:22 GMT
+  recorded_at: Tue, 26 May 2015 11:44:27 GMT
 - request:
     method: put
     uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82014022/customfields
@@ -952,7 +620,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 26 May 2015 11:44:22 GMT
+      - Tue, 26 May 2015 11:44:28 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -975,5 +643,77 @@ http_interactions:
         size="6"><customField><id>79789957</id><tag>Membership</tag><label>Level</label><text>individual</text></customField><customField><id>79789982</id><tag>Membership</tag><label>Supporter
         Level</label><text>Individual</text></customField><customField><id>79790020</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79790052</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79790080</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79790111</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField></customFields>
     http_version: 
-  recorded_at: Tue, 26 May 2015 11:44:22 GMT
+  recorded_at: Tue, 26 May 2015 11:44:28 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Joe%20Nerd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:44:29 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '468'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><person><id>82014022</id><contacts><email><id>157939461</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2015-05-26T11:01:32Z</createdOn><updatedOn>2015-05-26T11:01:37Z</updatedOn><firstName>Joe</firstName><lastName>Nerd</lastName></person></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 11:44:29 GMT
+- request:
+    method: delete
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82014022
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 11:44:29 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 11:44:29 GMT
 recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Processing_membership_signups/add_contact_details_to_CapsuleCRM.yml
+++ b/fixtures/vcr_cassettes/Processing_membership_signups/add_contact_details_to_CapsuleCRM.yml
@@ -1,0 +1,2186 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246430/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:00:06 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476874</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:00:06 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246552/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:30:07 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477151</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:30:07 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246558/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:31:22 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477165</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:31:23 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246564/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:32:49 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477174</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:32:50 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:33:03 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="24"><organisation><id>67713003</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T13:50:02Z</createdOn><updatedOn>2014-09-17T14:10:23Z</updatedOn><name>Bob's
+        Exotic Animals</name></organisation><organisation><id>67714053</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T14:19:41Z</createdOn><updatedOn>2014-09-17T14:21:08Z</updatedOn><name>Clive</name></organisation><organisation><id>61373912</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:06Z</createdOn><updatedOn>2014-05-16T14:16:06Z</updatedOn><name>company
+        A</name></organisation><organisation><id>61373993</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:13Z</createdOn><updatedOn>2014-05-16T14:16:13Z</updatedOn><name>company
+        B</name></organisation><organisation><id>61374051</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:18Z</createdOn><updatedOn>2014-05-16T14:16:18Z</updatedOn><name>company
+        C</name></organisation><organisation><id>61374058</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:24Z</createdOn><updatedOn>2014-05-16T14:16:24Z</updatedOn><name>company
+        D</name></organisation><organisation><id>61374067</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:31Z</createdOn><updatedOn>2014-05-16T14:16:31Z</updatedOn><name>company
+        E</name></organisation><organisation><id>61374071</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:37Z</createdOn><updatedOn>2014-05-16T14:16:37Z</updatedOn><name>company
+        F</name></organisation><organisation><id>61374074</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:42Z</createdOn><updatedOn>2014-05-16T14:16:42Z</updatedOn><name>company
+        G</name></organisation><person><id>37121194</id><contacts><email><id>70968278</id><emailAddress>tech@theodi.org</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2013-03-01T11:58:32Z</createdOn><updatedOn>2013-03-01T11:58:32Z</updatedOn><firstName>Default</firstName><lastName>User</lastName></person><organisation><id>67713852</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T14:12:41Z</createdOn><updatedOn>2014-09-17T14:13:00Z</updatedOn><name>Fish</name></organisation><organisation><id>67706736</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T13:07:05Z</createdOn><updatedOn>2014-09-17T14:05:51Z</updatedOn><name>Flibble
+        Inc</name></organisation><organisation><id>67713970</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T14:16:53Z</createdOn><updatedOn>2014-09-17T14:17:15Z</updatedOn><name>Met
+        Office</name></organisation><organisation><id>82002125</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T09:38:07Z</createdOn><updatedOn>2015-05-26T09:49:48Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation><organisation><id>67712662</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T13:38:26Z</createdOn><updatedOn>2014-09-17T13:44:13Z</updatedOn><name>Ping</name></organisation><organisation><id>52925184</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2013-12-16T08:54:56Z</createdOn><updatedOn>2014-08-28T08:14:19Z</updatedOn><name>Satan
+        Claus</name></organisation><organisation><id>67708912</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T13:14:11Z</createdOn><updatedOn>2014-09-17T13:17:53Z</updatedOn><name>Spong</name></organisation><person><id>36614070</id><contacts><email><id>69924901</id><emailAddress>tech@theodi.org</emailAddress></email></contacts><pictureURL>https://secure.gravatar.com/avatar/684cd479441406753cb68c1f125e7145?s=70&amp;r=G</pictureURL><createdOn>2013-02-19T15:25:32Z</createdOn><updatedOn>2013-03-01T11:58:50Z</updatedOn><firstName>Tech</firstName><lastName>Team</lastName></person><person><id>65867769</id><contacts><email><id>126705708</id><type>Work</type><emailAddress>turkleton@acme.com</emailAddress></email><phone><id>126705709</id><type>Work</type><phoneNumber>+44
+        1738 494032</phoneNumber></phone></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2014-08-12T08:55:48Z</createdOn><updatedOn>2014-08-12T08:55:51Z</updatedOn><firstName>Turk</firstName><lastName>Turkleton</lastName><jobTitle>CTO</jobTitle></person><person><id>65867773</id><contacts><email><id>126705714</id><type>Work</type><emailAddress>turkleton@acme.com</emailAddress></email><phone><id>126705715</id><type>Work</type><phoneNumber>+44
+        1738 494032</phoneNumber></phone></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2014-08-12T08:55:54Z</createdOn><updatedOn>2014-08-12T08:55:58Z</updatedOn><firstName>Turk</firstName><lastName>Turkleton</lastName><jobTitle>CTO</jobTitle></person><person><id>65867781</id><contacts><email><id>126705729</id><type>Work</type><emailAddress>turkleton@acme.com</emailAddress></email><phone><id>126705730</id><type>Work</type><phoneNumber>+44
+        1738 494032</phoneNumber></phone></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2014-08-12T08:56:07Z</createdOn><updatedOn>2014-08-12T08:56:11Z</updatedOn><firstName>Turk</firstName><lastName>Turkleton</lastName><jobTitle>CTO</jobTitle></person><person><id>65867787</id><contacts><email><id>126705737</id><type>Work</type><emailAddress>turkleton@acme.com</emailAddress></email><phone><id>126705738</id><type>Work</type><phoneNumber>+44
+        1738 494032</phoneNumber></phone></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2014-08-12T08:56:14Z</createdOn><updatedOn>2014-08-12T08:56:18Z</updatedOn><firstName>Turk</firstName><lastName>Turkleton</lastName><jobTitle>CTO</jobTitle></person><person><id>65867790</id><contacts><email><id>126705741</id><type>Work</type><emailAddress>turkleton@acme.com</emailAddress></email><phone><id>126705742</id><type>Work</type><phoneNumber>+44
+        1738 494032</phoneNumber></phone></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2014-08-12T08:56:20Z</createdOn><updatedOn>2014-08-12T08:56:24Z</updatedOn><firstName>Turk</firstName><lastName>Turkleton</lastName><jobTitle>CTO</jobTitle></person><organisation><id>67710108</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T13:22:03Z</createdOn><updatedOn>2014-09-17T13:23:10Z</updatedOn><name>WAT</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:33:03 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:36:41 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="24"><organisation><id>67713003</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T13:50:02Z</createdOn><updatedOn>2014-09-17T14:10:23Z</updatedOn><name>Bob's
+        Exotic Animals</name></organisation><organisation><id>67714053</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T14:19:41Z</createdOn><updatedOn>2014-09-17T14:21:08Z</updatedOn><name>Clive</name></organisation><organisation><id>61373912</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:06Z</createdOn><updatedOn>2014-05-16T14:16:06Z</updatedOn><name>company
+        A</name></organisation><organisation><id>61373993</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:13Z</createdOn><updatedOn>2014-05-16T14:16:13Z</updatedOn><name>company
+        B</name></organisation><organisation><id>61374051</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:18Z</createdOn><updatedOn>2014-05-16T14:16:18Z</updatedOn><name>company
+        C</name></organisation><organisation><id>61374058</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:24Z</createdOn><updatedOn>2014-05-16T14:16:24Z</updatedOn><name>company
+        D</name></organisation><organisation><id>61374067</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:31Z</createdOn><updatedOn>2014-05-16T14:16:31Z</updatedOn><name>company
+        E</name></organisation><organisation><id>61374071</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:37Z</createdOn><updatedOn>2014-05-16T14:16:37Z</updatedOn><name>company
+        F</name></organisation><organisation><id>61374074</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-05-16T14:16:42Z</createdOn><updatedOn>2014-05-16T14:16:42Z</updatedOn><name>company
+        G</name></organisation><person><id>37121194</id><contacts><email><id>70968278</id><emailAddress>tech@theodi.org</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2013-03-01T11:58:32Z</createdOn><updatedOn>2013-03-01T11:58:32Z</updatedOn><firstName>Default</firstName><lastName>User</lastName></person><organisation><id>67713852</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T14:12:41Z</createdOn><updatedOn>2014-09-17T14:13:00Z</updatedOn><name>Fish</name></organisation><organisation><id>67706736</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T13:07:05Z</createdOn><updatedOn>2014-09-17T14:05:51Z</updatedOn><name>Flibble
+        Inc</name></organisation><organisation><id>67713970</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T14:16:53Z</createdOn><updatedOn>2014-09-17T14:17:15Z</updatedOn><name>Met
+        Office</name></organisation><organisation><id>82002125</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T09:38:07Z</createdOn><updatedOn>2015-05-26T09:49:48Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation><organisation><id>67712662</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T13:38:26Z</createdOn><updatedOn>2014-09-17T13:44:13Z</updatedOn><name>Ping</name></organisation><organisation><id>52925184</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2013-12-16T08:54:56Z</createdOn><updatedOn>2014-08-28T08:14:19Z</updatedOn><name>Satan
+        Claus</name></organisation><organisation><id>67708912</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T13:14:11Z</createdOn><updatedOn>2014-09-17T13:17:53Z</updatedOn><name>Spong</name></organisation><person><id>36614070</id><contacts><email><id>69924901</id><emailAddress>tech@theodi.org</emailAddress></email></contacts><pictureURL>https://secure.gravatar.com/avatar/684cd479441406753cb68c1f125e7145?s=70&amp;r=G</pictureURL><createdOn>2013-02-19T15:25:32Z</createdOn><updatedOn>2013-03-01T11:58:50Z</updatedOn><firstName>Tech</firstName><lastName>Team</lastName></person><person><id>65867769</id><contacts><email><id>126705708</id><type>Work</type><emailAddress>turkleton@acme.com</emailAddress></email><phone><id>126705709</id><type>Work</type><phoneNumber>+44
+        1738 494032</phoneNumber></phone></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2014-08-12T08:55:48Z</createdOn><updatedOn>2014-08-12T08:55:51Z</updatedOn><firstName>Turk</firstName><lastName>Turkleton</lastName><jobTitle>CTO</jobTitle></person><person><id>65867773</id><contacts><email><id>126705714</id><type>Work</type><emailAddress>turkleton@acme.com</emailAddress></email><phone><id>126705715</id><type>Work</type><phoneNumber>+44
+        1738 494032</phoneNumber></phone></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2014-08-12T08:55:54Z</createdOn><updatedOn>2014-08-12T08:55:58Z</updatedOn><firstName>Turk</firstName><lastName>Turkleton</lastName><jobTitle>CTO</jobTitle></person><person><id>65867781</id><contacts><email><id>126705729</id><type>Work</type><emailAddress>turkleton@acme.com</emailAddress></email><phone><id>126705730</id><type>Work</type><phoneNumber>+44
+        1738 494032</phoneNumber></phone></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2014-08-12T08:56:07Z</createdOn><updatedOn>2014-08-12T08:56:11Z</updatedOn><firstName>Turk</firstName><lastName>Turkleton</lastName><jobTitle>CTO</jobTitle></person><person><id>65867787</id><contacts><email><id>126705737</id><type>Work</type><emailAddress>turkleton@acme.com</emailAddress></email><phone><id>126705738</id><type>Work</type><phoneNumber>+44
+        1738 494032</phoneNumber></phone></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2014-08-12T08:56:14Z</createdOn><updatedOn>2014-08-12T08:56:18Z</updatedOn><firstName>Turk</firstName><lastName>Turkleton</lastName><jobTitle>CTO</jobTitle></person><person><id>65867790</id><contacts><email><id>126705741</id><type>Work</type><emailAddress>turkleton@acme.com</emailAddress></email><phone><id>126705742</id><type>Work</type><phoneNumber>+44
+        1738 494032</phoneNumber></phone></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/person_avatar_70.png</pictureURL><createdOn>2014-08-12T08:56:20Z</createdOn><updatedOn>2014-08-12T08:56:24Z</updatedOn><firstName>Turk</firstName><lastName>Turkleton</lastName><jobTitle>CTO</jobTitle></person><organisation><id>67710108</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2014-09-17T13:22:03Z</createdOn><updatedOn>2014-09-17T13:23:10Z</updatedOn><name>WAT</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:36:42 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:37:01 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246580
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:37:01 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246580/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:37:01 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477221</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:37:02 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:37:02 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:37:02 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:37:03 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:37:03 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:37:03 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:37:03 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:37:04 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:37:04 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:37:05 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:37:05 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:37:05 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:37:05 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>&lt;10</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:37:06 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:37:06 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:37:06 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:37:07 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:37:07 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:37:07 GMT
+- request:
+    method: delete
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:37:10 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Connection:
+      - close
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:37:11 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246587/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:38:53 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477232</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:38:53 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246617/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:00 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477253</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246638/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:44:21 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477284</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:44:21 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246641/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:44:49 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477286</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:44:49 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246644/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:45:25 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477294</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:45:25 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246648/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:46:18 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477298</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:46:18 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:47:31 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246651
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:47:31 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246651/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:47:32 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477305</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:47:32 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:47:32 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:47:32 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:47:33 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:47:33 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:47:33 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:47:33 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:47:34 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:47:34 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:47:35 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:47:35 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:47:35 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:47:35 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>&lt;10</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:47:36 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:47:36 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:47:36 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:47:36 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:47:37 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:47:37 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:47:38 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '459'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82006104</id><contacts><email><id>157929009</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T10:38:45Z</createdOn><updatedOn>2015-05-26T10:42:26Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:47:38 GMT
+- request:
+    method: delete
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:47:38 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:47:38 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:14 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '459'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82006319</id><contacts><email><id>157929481</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T10:49:07Z</createdOn><updatedOn>2015-05-26T10:49:14Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:14 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:15 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246660
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:15 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246660/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:15 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477349</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:15 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:16 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:16 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:16 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787806</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787807</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787808</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787809</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787810</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787811</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787812</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787813</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:17 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:17 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787806</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787807</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787808</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787809</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787810</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787811</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787812</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787813</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:17 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:18 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787806</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787807</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787808</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787809</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787810</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787811</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787812</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787813</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:18 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:18 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787806</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787807</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787808</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787809</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787810</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787811</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787812</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787813</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:18 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:19 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787806</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787807</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787808</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787809</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787810</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787811</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787812</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787813</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:19 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>&lt;10</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:19 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787806</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787807</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787808</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787809</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787810</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787811</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787812</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787813</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:20 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:20 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787806</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787807</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787808</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787809</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787810</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787811</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787812</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787813</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:20 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:21 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787806</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787807</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787808</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787809</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787810</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787811</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787812</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787813</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:21 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:21 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '459'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82006319</id><contacts><email><id>157929481</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T10:49:07Z</createdOn><updatedOn>2015-05-26T10:49:14Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:21 GMT
+- request:
+    method: delete
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:22 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:22 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Processing_membership_signups/add_signups_to_correct_queues.yml
+++ b/fixtures/vcr_cassettes/Processing_membership_signups/add_signups_to_correct_queues.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 08:50:05 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '74'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="0"/>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 08:50:05 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Processing_membership_signups/add_signups_to_invoicing_queue.yml
+++ b/fixtures/vcr_cassettes/Processing_membership_signups/add_signups_to_invoicing_queue.yml
@@ -1,0 +1,1714 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246338/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:45:02 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476711</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:45:02 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246340/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:45:17 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476712</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:45:17 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246344/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:46:15 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476713</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:46:15 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:24 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246367
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:24 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246367/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:24 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476757</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:25 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:25 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:25 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:26 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:26 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:26 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:26 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:27 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:27 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:27 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:27 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:28 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:28 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>&lt;10</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:29 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:29 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:29 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:29 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:30 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:30 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246586/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:38:45 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477231</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:38:45 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:41:52 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '459'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82006104</id><contacts><email><id>157929009</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T10:38:45Z</createdOn><updatedOn>2015-05-26T10:39:18Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:41:52 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:41:52 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246616
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:41:52 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246616/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:41:53 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477252</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:41:53 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:41:53 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:41:54 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:41:54 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:41:54 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:41:55 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:41:55 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:41:55 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:41:55 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:41:56 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:41:56 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:41:56 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:41:57 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>&lt;10</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:41:57 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:41:57 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:41:58 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:41:58 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:41:58 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:41:58 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:06 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '74'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="0"/>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:06 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/organisation
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<organisation>\n  <about
+        nil=\"true\"/>\n  <name>Nerd Enterprises Inc</name>\n  <contacts>\n    <email>\n
+        \     <type nil=\"true\"/>\n      <emailAddress>finance@nerd.eg</emailAddress>\n
+        \   </email>\n  </contacts>\n</organisation>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:06 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:06 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:07 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246659
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:07 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246659/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477348</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:08 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/tag/Membership
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:08 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:09 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '200'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>79787806</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:09 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:09 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '317'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="2"><customField><id>79787806</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787807</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:10 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:10 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '420'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="3"><customField><id>79787806</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787807</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787808</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:10 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:11 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '539'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="4"><customField><id>79787806</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787807</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787808</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787809</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:11 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:11 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '648'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="5"><customField><id>79787806</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787807</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787808</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787809</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787810</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:11 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>&lt;10</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:12 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '751'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="6"><customField><id>79787806</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787807</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787808</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787809</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787810</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787811</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:12 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:13 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '860'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="7"><customField><id>79787806</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787807</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787808</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787809</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787810</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787811</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787812</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:13 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006319/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:13 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787806</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787807</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787808</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787809</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787810</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787811</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787812</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787813</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:13 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Processing_membership_signups/generate_correct_prices_and_descriptions.yml
+++ b/fixtures/vcr_cassettes/Processing_membership_signups/generate_correct_prices_and_descriptions.yml
@@ -1,0 +1,519 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:47:52 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '372'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82002125</id><contacts/><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T09:38:07Z</createdOn><updatedOn>2015-05-26T09:46:39Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:47:52 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:47:52 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246363
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:47:53 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246363/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:47:53 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476749</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:47:53 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:47:54 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:47:54 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:47:54 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:47:54 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:47:55 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:47:55 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:47:55 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:47:56 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:47:56 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:47:56 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:47:57 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:47:57 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>&lt;10</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:47:57 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:47:57 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:47:58 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:47:58 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:47:58 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:47:59 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Processing_membership_signups/generate_correct_prices_and_descriptions/_1000_commercial_ODI_Corporate_Supporter_01010101_Commercial_annual_invoice_payment_Corporate_supporter_2200_.yml
+++ b/fixtures/vcr_cassettes/Processing_membership_signups/generate_correct_prices_and_descriptions/_1000_commercial_ODI_Corporate_Supporter_01010101_Commercial_annual_invoice_payment_Corporate_supporter_2200_.yml
@@ -1,0 +1,1604 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246347/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:46:29 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476715</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:46:30 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246364/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:48:00 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476750</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:48:00 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:38 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246371
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:38 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246371/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:39 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476761</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:39 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:39 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:39 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:40 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:40 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Corporate supporter</text>\n
+        \   <tag>Membership</tag>\n    <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n
+        \ </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:41 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '964'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:41 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:41 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '964'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:41 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:42 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '964'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:42 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:42 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '964'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:42 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>&gt;1000</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:43 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '966'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:43 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:44 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '966'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:44 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:44 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '966'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:44 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246590/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:39:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477234</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:39:08 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:15 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246621
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:16 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246621/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:16 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477269</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:16 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:17 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:17 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:17 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:17 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Corporate supporter</text>\n
+        \   <tag>Membership</tag>\n    <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n
+        \ </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:18 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '964'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:18 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:18 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '964'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:19 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:19 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '964'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:19 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:20 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '964'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:20 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>&gt;1000</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:20 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '966'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:20 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:21 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '966'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:21 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:21 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '966'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:22 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:31 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '459'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82006321</id><contacts><email><id>157929487</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T10:49:24Z</createdOn><updatedOn>2015-05-26T10:49:31Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:31 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:31 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246663
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:32 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246663/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:32 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477355</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:32 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:33 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:33 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:33 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:33 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Corporate supporter</text>\n
+        \   <tag>Membership</tag>\n    <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n
+        \ </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:34 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '964'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:34 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:34 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '964'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:35 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:35 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '964'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:35 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:36 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '964'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:36 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>&gt;1000</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:36 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '966'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:36 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:37 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '966'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:37 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:37 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '966'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:38 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Processing_membership_signups/generate_correct_prices_and_descriptions/_10_commercial_ODI_Supporter_01010101_Commercial_annual_invoice_payment_Supporter_720_.yml
+++ b/fixtures/vcr_cassettes/Processing_membership_signups/generate_correct_prices_and_descriptions/_10_commercial_ODI_Supporter_01010101_Commercial_annual_invoice_payment_Supporter_720_.yml
@@ -1,0 +1,1592 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246345/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:46:22 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476714</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:46:22 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:31 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246369
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:31 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246369/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:32 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476759</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:32 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:32 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:32 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:33 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:33 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:33 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:34 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:34 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:34 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:35 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:35 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:35 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:35 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>&lt;10</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:36 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:36 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:36 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:36 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:37 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:37 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246588/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:39:01 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477233</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:39:01 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246618
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:08 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246618/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477254</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:09 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:09 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:09 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:10 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:10 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:10 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:10 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:11 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:11 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:12 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:12 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:12 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:12 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>&lt;10</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:13 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:13 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:13 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:14 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:14 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:14 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:23 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '74'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="0"/>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:23 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/organisation
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<organisation>\n  <about
+        nil=\"true\"/>\n  <name>Nerd Enterprises Inc</name>\n  <contacts>\n    <email>\n
+        \     <type nil=\"true\"/>\n      <emailAddress>finance@nerd.eg</emailAddress>\n
+        \   </email>\n  </contacts>\n</organisation>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:23 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:24 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:24 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246662
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:24 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246662/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:25 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477354</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:25 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:25 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/tag/Membership
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:25 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:26 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '200'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:26 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:26 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '317'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="2"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:27 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:27 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '420'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="3"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:27 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:28 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '539'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="4"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:28 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:28 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '648'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="5"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:28 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>&lt;10</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:29 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '751'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="6"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:29 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:29 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '860'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="7"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:30 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:30 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>&lt;10</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:30 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Processing_membership_signups/generate_correct_prices_and_descriptions/_251-1000_non_commercial_ODI_Supporter_01010101_Non_Commercial_annual_invoice_payment_Supporter_720_.yml
+++ b/fixtures/vcr_cassettes/Processing_membership_signups/generate_correct_prices_and_descriptions/_251-1000_non_commercial_ODI_Supporter_01010101_Non_Commercial_annual_invoice_payment_Supporter_720_.yml
@@ -1,0 +1,1601 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246351/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:46:44 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476717</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:46:44 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246366/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:48:15 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476752</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:48:15 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:53 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246373
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:53 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246373/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:53 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476763</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:53 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:54 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:54 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:54 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:55 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:55 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:55 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:56 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:56 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:56 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:56 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:57 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:57 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>251-1000</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:57 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:58 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:58 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:58 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:59 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:59 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246594/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:39:23 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477236</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:39:23 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:30 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246624
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:30 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246624/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:31 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477271</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:31 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:31 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:32 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:32 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:32 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:33 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:33 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:33 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:33 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:34 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:34 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:34 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:35 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>251-1000</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:35 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:35 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:36 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:36 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:36 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:36 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:46 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '459'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82006321</id><contacts><email><id>157929487</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T10:49:24Z</createdOn><updatedOn>2015-05-26T10:49:42Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:46 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:46 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246666
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:47 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246666/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:47 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477361</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:47 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:48 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:48 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:48 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:48 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:49 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:49 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:49 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:50 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:50 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:50 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:51 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:51 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>251-1000</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:51 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:51 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:52 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:52 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:52 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:53 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Processing_membership_signups/generate_correct_prices_and_descriptions/_51-250_non_commercial_ODI_Supporter_01010101_Non_Commercial_annual_invoice_payment_Supporter_720_.yml
+++ b/fixtures/vcr_cassettes/Processing_membership_signups/generate_correct_prices_and_descriptions/_51-250_non_commercial_ODI_Supporter_01010101_Non_Commercial_annual_invoice_payment_Supporter_720_.yml
@@ -1,0 +1,1601 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246350/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:46:37 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476716</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:46:37 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246365/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:48:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476751</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:48:08 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:45 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246372
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:46 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246372/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:46 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476762</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:46 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:47 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:47 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:47 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '966'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:47 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:48 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:48 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:48 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:48 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:49 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:49 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:49 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:50 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>51-250</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:50 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:50 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:51 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:51 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:49:51 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:49:51 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246592/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:39:15 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477235</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:39:16 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:23 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246623
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:23 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246623/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:23 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477270</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:24 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:24 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:24 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:25 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '966'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:25 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:25 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:25 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:26 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:26 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:26 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:27 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:27 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:27 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>51-250</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:28 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:28 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:28 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:28 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:29 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:29 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:38 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '459'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82006321</id><contacts><email><id>157929487</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T10:49:24Z</createdOn><updatedOn>2015-05-26T10:49:35Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:38 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:39 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246664
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:39 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246664/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:39 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477356</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:40 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:40 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:40 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:41 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '966'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Corporate supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:41 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:41 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:41 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:42 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:42 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:42 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:43 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:43 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>&gt;1000</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:43 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>51-250</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:44 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:44 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:44 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:44 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:45 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '954'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>51-250</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:45 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Processing_membership_signups/generate_invoice.yml
+++ b/fixtures/vcr_cassettes/Processing_membership_signups/generate_invoice.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 08:53:30 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '74'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="0"/>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 08:53:30 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Processing_membership_signups/handle_payment_methods_and_frequencies/_credit_card_annual_cus_12345_ODI_Supporter_01010101_Commercial_annual_card_payment_.yml
+++ b/fixtures/vcr_cassettes/Processing_membership_signups/handle_payment_methods_and_frequencies/_credit_card_annual_cus_12345_ODI_Supporter_01010101_Commercial_annual_card_payment_.yml
@@ -1,0 +1,1561 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246357/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:47:06 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476733</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:47:06 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:15 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246377
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:15 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246377/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:15 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476766</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:16 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:16 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:16 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:17 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:17 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:17 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:17 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:18 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:18 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:18 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:19 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:19 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:19 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:20 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:20 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:20 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:20 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:21 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:21 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246599/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:39:46 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477239</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:39:46 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:52 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246627
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:52 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246627/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:53 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477274</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:53 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:53 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:54 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:54 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:54 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:55 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:55 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:55 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:55 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:56 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:56 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:56 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:57 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:57 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:57 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:58 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:58 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:58 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:58 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:09 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '459'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82006321</id><contacts><email><id>157929487</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T10:49:24Z</createdOn><updatedOn>2015-05-26T10:49:42Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:09 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:09 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246669
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:10 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246669/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:10 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477365</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:10 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:11 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:11 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:12 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:12 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:12 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:12 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:13 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:13 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:13 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:14 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:14 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Connection:
+      - close
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:14 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:15 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:15 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:15 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:15 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:16 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:16 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Processing_membership_signups/handle_payment_methods_and_frequencies/_credit_card_monthly_cus_54321_ODI_Supporter_01010101_Commercial_monthly_card_payment_.yml
+++ b/fixtures/vcr_cassettes/Processing_membership_signups/handle_payment_methods_and_frequencies/_credit_card_monthly_cus_54321_ODI_Supporter_01010101_Commercial_monthly_card_payment_.yml
@@ -1,0 +1,1559 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246359/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:47:13 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476746</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:47:13 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:22 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246378
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:22 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246378/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:23 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476767</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:23 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:23 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:24 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:24 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:24 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:25 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:25 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:25 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:25 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:26 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:26 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:26 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:26 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:27 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:27 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:28 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:28 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:28 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:28 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246602/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:39:53 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477240</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:39:53 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:00 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246629
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246629/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:00 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477275</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:00 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:01 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:01 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:01 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:02 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:02 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:02 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:03 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:03 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:03 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:03 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:04 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:04 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:05 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:05 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:05 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:05 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:06 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:06 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:17 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '459'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82006321</id><contacts><email><id>157929487</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T10:49:24Z</createdOn><updatedOn>2015-05-26T10:49:42Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:17 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:17 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246670
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:17 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246670/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:18 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477366</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:18 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:18 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:18 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:19 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:19 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:19 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:20 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:20 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:20 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:21 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:21 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:21 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:21 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:22 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:22 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:22 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:23 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:23 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:23 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Processing_membership_signups/handle_payment_methods_and_frequencies/_direct_debit_annual_dd_32415_ODI_Supporter_01010101_Commercial_annual_dd_payment_.yml
+++ b/fixtures/vcr_cassettes/Processing_membership_signups/handle_payment_methods_and_frequencies/_direct_debit_annual_dd_32415_ODI_Supporter_01010101_Commercial_annual_dd_payment_.yml
@@ -1,0 +1,1559 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246360/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:47:20 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476747</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:47:20 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:29 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246380
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:30 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246380/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:30 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476768</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:30 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:31 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:31 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:31 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:31 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:32 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:32 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:33 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:33 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:33 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:33 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:34 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:34 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:34 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:34 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:35 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:35 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:36 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:36 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246606/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:40:00 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477242</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:40:01 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:07 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246630
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:07 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246630/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477276</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:08 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:09 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:09 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:09 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:10 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:10 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:10 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:10 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:11 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:11 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:11 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:11 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:12 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:12 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:12 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:13 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:13 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:13 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:24 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '459'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82006321</id><contacts><email><id>157929487</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T10:49:24Z</createdOn><updatedOn>2015-05-26T10:49:42Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:24 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:24 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246671
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:25 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246671/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:25 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477367</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:25 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:26 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:26 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:26 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:26 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:27 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:27 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:27 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:28 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:28 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:28 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:29 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:29 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:29 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:29 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:30 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:30 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:30 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:31 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Processing_membership_signups/handle_payment_methods_and_frequencies/_direct_debit_monthly_dd_32104_ODI_Supporter_01010101_Commercial_monthly_dd_payment_.yml
+++ b/fixtures/vcr_cassettes/Processing_membership_signups/handle_payment_methods_and_frequencies/_direct_debit_monthly_dd_32104_ODI_Supporter_01010101_Commercial_monthly_dd_payment_.yml
@@ -1,0 +1,1559 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246361/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:47:27 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476748</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:47:27 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:37 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246381
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:37 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246381/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:37 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476769</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:37 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:38 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:38 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:38 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:39 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:39 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:39 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:40 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:40 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:40 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:40 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:41 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:41 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:42 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:42 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:42 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:42 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:43 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:43 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246608/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:40:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477243</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:40:09 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:14 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246632
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:15 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246632/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:15 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477277</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:15 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:16 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:16 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:16 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:16 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:17 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:17 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:17 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:18 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:18 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:18 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:19 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:19 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:19 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:19 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:20 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:20 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:43:20 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:43:21 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:32 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '459'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82006321</id><contacts><email><id>157929487</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T10:49:24Z</createdOn><updatedOn>2015-05-26T10:49:42Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:32 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:32 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246672
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:32 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246672/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:33 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477368</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:33 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:33 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:33 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:34 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:34 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:34 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:35 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:35 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:35 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:36 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:36 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:36 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:36 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:37 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:37 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:37 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:38 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:38 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:38 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Processing_membership_signups/handle_payment_methods_and_frequencies/_invoice_annual_ODI_Supporter_01010101_Commercial_annual_invoice_payment_.yml
+++ b/fixtures/vcr_cassettes/Processing_membership_signups/handle_payment_methods_and_frequencies/_invoice_annual_ODI_Supporter_01010101_Commercial_annual_invoice_payment_.yml
@@ -1,0 +1,1559 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246352/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:46:51 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476718</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:46:51 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:00 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246374
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:00 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246374/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:01 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476764</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:01 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:01 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:01 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:02 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:02 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:02 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:03 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:03 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:03 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:04 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:04 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:05 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:05 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:05 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:05 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:06 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:06 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:06 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:07 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246596/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:39:30 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477237</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:39:31 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:38 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246625
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:38 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246625/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:38 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477272</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:38 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:39 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:39 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:39 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:39 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:40 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:40 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:41 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:41 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:41 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:41 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:42 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:42 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:42 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:42 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:43 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:43 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:44 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:44 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:53 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '459'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82006321</id><contacts><email><id>157929487</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T10:49:24Z</createdOn><updatedOn>2015-05-26T10:49:42Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:53 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:54 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246667
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:54 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246667/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:54 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477362</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:55 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:55 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:55 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:56 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:56 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:56 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:56 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:57 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:57 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:57 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:58 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:58 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '956'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>251-1000</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:58 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:59 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:59 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:49:59 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:49:59 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:00 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:00 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/Processing_membership_signups/handle_payment_methods_and_frequencies/_invoice_monthly_ODI_Supporter_01010101_Commercial_annual_invoice_payment_.yml
+++ b/fixtures/vcr_cassettes/Processing_membership_signups/handle_payment_methods_and_frequencies/_invoice_monthly_ODI_Supporter_01010101_Commercial_annual_invoice_payment_.yml
@@ -1,0 +1,1559 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246354/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:46:58 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476719</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:46:58 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246376
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:08 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246376/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4476765</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:08 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:09 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:09 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:09 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:10 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:10 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:10 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:11 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:11 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:11 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:11 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:12 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:12 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:12 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:13 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:13 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:13 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82002125/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 09:50:14 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79783789</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79783790</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79783792</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79783793</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79783794</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79783795</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79783796</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79783797</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 09:50:14 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246597/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:39:38 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477238</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:39:39 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:45 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246626
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:45 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246626/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:45 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477273</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:46 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:46 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:46 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:47 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:47 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:47 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:47 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:48 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:48 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:48 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:49 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:49 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:49 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:50 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:50 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:50 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:50 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006104/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:42:51 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787557</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787558</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787559</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787561</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787562</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787563</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787564</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787565</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:42:51 GMT
+- request:
+    method: get
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party?q=Nerd%20Enterprises%20Inc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:01 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '459'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><parties size="1"><organisation><id>82006321</id><contacts><email><id>157929487</id><emailAddress>finance@nerd.eg</emailAddress></email></contacts><pictureURL>https://d365sd3k9yw37.cloudfront.net/a/1431697050/theme/default/images/org_avatar_70.png</pictureURL><createdOn>2015-05-26T10:49:24Z</createdOn><updatedOn>2015-05-26T10:49:42Z</updatedOn><name>Nerd
+        Enterprises Inc</name></organisation></parties>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:01 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/opportunity
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<opportunity>\n  <name>Membership
+        at supporter level</name>\n  <currency>GBP</currency>\n  <value type=\"integer\">60</value>\n
+        \ <milestone>Invoiced</milestone>\n  <probability type=\"integer\">100</probability>\n
+        \ <description>Membership #: 01010101</description>\n  <duration type=\"integer\">12</duration>\n
+        \ <durationBasis>MONTH</durationBasis>\n  <expectedCloseDate type=\"date\">2015-05-26</expectedCloseDate>\n
+        \ <owner><CAPSULECRM_DEFAULT_OWNER></owner>\n</opportunity>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:01 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Location:
+      - https://<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246668
+      Content-Length:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:01 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/opportunity/3246668/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Type</label>\n    <text>Membership</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:02 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '178'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="1"><customField><id>4477363</id><label>Type</label><text>Membership</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:02 GMT
+- request:
+    method: post
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/tag/Membership
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tags>\n  <tag>\n    <name>Membership</name>\n
+        \ </tag>\n</tags>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:02 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '126'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><tags size="1"><tag><id>796299</id><name>Membership</name></tag></tags>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:03 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Level</label>\n    <text>supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:03 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:03 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Supporter Level</label>\n    <text>Supporter</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:04 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:04 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>ID</label>\n    <text>01010101</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:05 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:05 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Joined</label>\n    <text nil=\"true\"/>\n    <tag>Membership</tag>\n
+        \   <date type=\"date\">2015-05-26</date>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:05 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:05 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Email</label>\n    <text>joe@nerd.eg</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:06 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:06 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Size</label>\n    <text>10-50</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:07 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:07 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Sector</label>\n    <text>Healthcare</text>\n    <tag>Membership</tag>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:07 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:07 GMT
+- request:
+    method: put
+    uri: https://<CAPSULECRM_API_TOKEN>:x@<CAPSULECRM_ACCOUNT_NAME>.capsulecrm.com/api/party/82006321/customfields
+    body:
+      encoding: US-ASCII
+      string: ! "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<customFields>\n  <customField>\n
+        \   <label>Company Number</label>\n    <text>08030289</text>\n    <tag nil=\"true\"/>\n
+        \   <date nil=\"true\"/>\n    <boolean nil=\"true\"/>\n  </customField>\n</customFields>\n"
+    headers:
+      User-Agent:
+      - CapsuleCRM ruby gem
+      Content-Type:
+      - text/xml
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 May 2015 10:50:08 GMT
+      Server:
+      - Apache
+      X-Frame-Options:
+      - DENY
+      Set-Cookie:
+      - JSESSIONID=; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/
+      Content-Length:
+      - '953'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Type:
+      - ! '*/*;charset=UTF-8'
+    body:
+      encoding: US-ASCII
+      string: <?xml version="1.0" encoding="UTF-8" standalone="yes"?><customFields
+        size="8"><customField><id>79787818</id><tag>Membership</tag><label>Level</label><text>supporter</text></customField><customField><id>79787819</id><tag>Membership</tag><label>Supporter
+        Level</label><text>Supporter</text></customField><customField><id>79787820</id><tag>Membership</tag><label>ID</label><text>01010101</text></customField><customField><id>79787821</id><tag>Membership</tag><label>Joined</label><date>2015-05-26T00:00:00Z</date></customField><customField><id>79787826</id><tag>Membership</tag><label>Email</label><text>joe@nerd.eg</text></customField><customField><id>79787827</id><tag>Membership</tag><label>Size</label><text>10-50</text></customField><customField><id>79787828</id><tag>Membership</tag><label>Sector</label><text>Healthcare</text></customField><customField><id>79787829</id><label>Company
+        Number</label><text>08030289</text></customField></customFields>
+    http_version: 
+  recorded_at: Tue, 26 May 2015 10:50:08 GMT
+recorded_with: VCR 2.9.3

--- a/lib/capsulecrm/capsule_helper.rb
+++ b/lib/capsulecrm/capsule_helper.rb
@@ -1,5 +1,31 @@
 module CapsuleHelper
 
+  def find_or_create_person(party)
+    person = find_person(party['email'])
+    if person.nil?
+      first_name, last_name = party['name'].split(" ")
+      person = CapsuleCRM::Person.new(
+        first_name: first_name,
+        last_name: last_name
+      )
+      person.emails << CapsuleCRM::Email.new(person, address: party['email'])
+      person.save
+    end
+    person
+  end
+
+  def find_or_create_organization(party)
+    org = find_organization(party['name'])
+    if org.nil?
+      org = CapsuleCRM::Organisation.new(
+        name: party['name']
+      )
+      org.emails << CapsuleCRM::Email.new(org, address: party['email'])
+      org.save
+    end
+    org
+  end
+
   def find_organization(query)
     # Run fuzzy capsuleCRM match
     orgs = CapsuleCRM::Organisation.find_all(:q => query)


### PR DESCRIPTION
Rather than relying on the Capsule / Xero sync, which is error prone (especially for individuals). The only advantage we lose here is the ability to link to invoices directly from Capsule, but, as we're transistioning to Chargify, and linking that to Xero soon, we won't lose a whole lot of functionlity.

Once this is deployed, we'll need to disable the Capsule / Xero link in Capsule.