### PR TITLE
Don't add members via Eventbrite

### DIFF
--- a/features/attendee_monitoring.feature
+++ b/features/attendee_monitoring.feature
@@ -94,23 +94,3 @@ Feature: Monitoring attendee signups
     And I should be added to the invoicing queue along with others
     When the attendee monitor runs
 
-  Scenario: free membership tickets get queued in Capsule
-    Given there is no person in CapsuleCRM called "Bob Fish"
-    And I have signed up for 1 ticket called "Individual supporter package" which has a net price of 100.00
-    Then I should be given the "individual" membership
-    And my details should be added to the Capsule queue
-    When the attendee monitor runs
-
-  Scenario: SME package tickets get queued in Capsule
-    Given there is no person in CapsuleCRM called "Bob Fish"
-    And I have signed up for 1 ticket called "Summit SME package" which has a net price of 200.00
-    Then I should be given the "supporter" membership
-    And my details should be added to the Capsule queue
-    When the attendee monitor runs
-
-  Scenario: Platinum corporate package tickets get queued in Capsule
-    Given there is no person in CapsuleCRM called "Bob Fish"
-    And I have signed up for 1 ticket called "Summit platinum corporate package" which has a net price of 300.00
-    Then I should be given the "supporter" membership
-    And my details should be added to the Capsule queue
-    When the attendee monitor runs

--- a/lib/eventbrite/attendee_monitor.rb
+++ b/lib/eventbrite/attendee_monitor.rb
@@ -68,24 +68,6 @@ class AttendeeMonitor
               'description' => line_description(ticket, event_details['title'], date, a['attendee']['first_name'], a['attendee']['last_name'], a['attendee']['email'], order_id, custom_answer(a['attendee'], 'Membership Number'))
             }
           end
-
-          if has_membership?(ticket)
-            attendee = a['attendee']
-
-            membership = {
-              'product_name' => membership_type(ticket),
-              'supporter_level' => membership_type(ticket),
-              'join_date' => Date.today,
-              'contact_email' => attendee['email']
-            }
-
-            party = {
-              'name' => "#{attendee['first_name']} #{attendee['last_name']}",
-              'email' => attendee['email']
-            }
-
-            Resque.enqueue(SendSignupToCapsule, party, membership)
-          end
         end
 
         if invoice_details['line_items'].count > 0


### PR DESCRIPTION
This is for https://github.com/theodi/member-directory/issues/518

Adding members to Capsule via Eventbrite ticket purchases was causing more problems than it was solving.

People would signup using their personal name in Eventbrite and this value would propagated to Capsule and then the member directory.

However, if you wanted to change the person's name to a company name it would work for a while until the Eventbrite job ran. When that job ran it would try to add a new member to Capsule because people are fetched from Capsule using their company name (for organizations). This would fail because of the database constraint on email.

We're disabling this functionality as the amount of tickets that come through via Eventbrite is minimal so the team will manually create the entry in Capsule as necessary.