### PR TITLE
Allow time since to be passed in if required

### DIFF
--- a/lib/mailing_list/sync_mailing_list.rb
+++ b/lib/mailing_list/sync_mailing_list.rb
@@ -8,10 +8,15 @@ class SyncMailingList
   end
 
   attr_writer :members, :queue
+  attr_reader :since
+
+  def initialize(since = 24.hours.ago)
+    @since = since
+  end
 
   def perform
     members.each do |member|
-      if updated_within_24_hours?(member)
+      if requires_update?(member)
         queue.enqueue(UpdateMailingList, member.id, member.class.to_s.demodulize)
       end
     end
@@ -19,8 +24,8 @@ class SyncMailingList
 
   private
 
-  def updated_within_24_hours?(member)
-    member.updated_at > 24.hours.ago
+  def requires_update?(member)
+    member.updated_at > since
   end
 
   def queue


### PR DESCRIPTION
We provide a sensible default (24 hours ago) so that things continue to work but allow
the time period to be passed in so we can manually run this job in a
console as necessary.

For example:

    SyncMailingList.new(1.week.ago).perform